### PR TITLE
fix: resolve amp CLI not found and exit code 1 when running binary outside project directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "url": "https://github.com/tao12345666333/amp-acp"
   },
   "scripts": {
-    "build": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js",
-    "build:binary": "bun build src/index.ts --compile --outfile dist/amp-acp",
+    "build": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun scripts/patch-find-amp.ts",
+    "build:binary": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun scripts/patch-find-amp.ts && bun build dist/index.js --compile --outfile dist/amp-acp",
     "start": "bun dist/index.js",
     "lint": "tsc --noEmit",
     "test": "bun test src/",
-    "test:binary": "bun build src/index.ts --compile --outfile dist/amp-acp-test && bun test test/binary.test.ts",
+    "test:binary": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun scripts/patch-find-amp.ts && bun build dist/index.js --compile --outfile dist/amp-acp-test && bun test test/binary.test.ts",
     "test:all": "bun run test && bun run test:binary"
   },
   "dependencies": {

--- a/scripts/patch-find-amp.ts
+++ b/scripts/patch-find-amp.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+/**
+ * Postbuild script that patches the bundled findAmpCommand() from @sourcegraph/amp-sdk
+ * to fallback to the system-installed `amp` CLI when the local @sourcegraph/amp package
+ * cannot be resolved (which always happens when running as a compiled binary outside
+ * the amp-acp project directory).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distFile = path.resolve(import.meta.dir, '../dist/index.js');
+
+const original = `function findAmpCommand() {
+  try {
+    const require2 = createRequire(import.meta.url);
+    const pkgJsonPath = require2.resolve("@sourcegraph/amp/package.json");
+    const pkgJsonRaw = fs.readFileSync(pkgJsonPath, "utf8");
+    const pkgJson = JSON.parse(pkgJsonRaw);
+    if (pkgJson.bin?.amp) {
+      const binPath = path.join(path.dirname(pkgJsonPath), pkgJson.bin.amp);
+      return {
+        command: "node",
+        args: [binPath]
+      };
+    }
+    throw new Error("Local @sourcegraph/amp package found but no bin entry for Amp CLI");
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Local @sourcegraph/amp")) {
+      throw error;
+    }
+    throw new Error("Could not find local @sourcegraph/amp package. Make sure it is installed.");
+  }
+}`;
+
+const patched = `function findAmpCommand() {
+  try {
+    const require2 = createRequire(import.meta.url);
+    const pkgJsonPath = require2.resolve("@sourcegraph/amp/package.json");
+    const pkgJsonRaw = fs.readFileSync(pkgJsonPath, "utf8");
+    const pkgJson = JSON.parse(pkgJsonRaw);
+    if (pkgJson.bin?.amp) {
+      const binPath = path.join(path.dirname(pkgJsonPath), pkgJson.bin.amp);
+      return {
+        command: "node",
+        args: [binPath]
+      };
+    }
+    throw new Error("Local @sourcegraph/amp package found but no bin entry for Amp CLI");
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Local @sourcegraph/amp")) {
+      throw error;
+    }
+    // Fallback: look for amp CLI in well-known locations and PATH
+    const { execFileSync } = require("node:child_process");
+    const os = require("node:os");
+    const candidates = [];
+    const homeDir = os.homedir();
+    candidates.push(path.join(homeDir, ".amp", "bin", "amp"));
+    if (process.platform === "win32") {
+      candidates.push(path.join(homeDir, ".amp", "bin", "amp.exe"));
+    }
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        return { command: candidate, args: [] };
+      }
+    }
+    try {
+      const whichCmd = process.platform === "win32" ? "where" : "which";
+      const result = execFileSync(whichCmd, ["amp"], { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+      if (result) {
+        return { command: result, args: [] };
+      }
+    } catch {}
+    throw new Error("Could not find amp CLI. Install it from https://ampcode.com or ensure @sourcegraph/amp is available.");
+  }
+}`;
+
+const content = fs.readFileSync(distFile, 'utf8');
+
+if (!content.includes(original)) {
+  console.error('Warning: Could not find the expected findAmpCommand() function to patch.');
+  console.error('The @sourcegraph/amp-sdk version may have changed. Please update the patch script.');
+  process.exit(1);
+}
+
+const patched_content = content.replace(original, patched);
+fs.writeFileSync(distFile, patched_content);
+console.error('Patched findAmpCommand() with system amp CLI fallback.');

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,6 +153,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
 
     const options: Record<string, unknown> = {
       cwd: s.cwd,
+      env: { TERM: 'dumb' },
     };
 
     if (s.mode === 'bypass') {


### PR DESCRIPTION
## Problem

When running the compiled amp-acp binary from a directory other than the project root (e.g. via Zed as a native agent), two errors occur:

1. **`Could not find local @sourcegraph/amp package`** - `findAmpCommand()` in `@sourcegraph/amp-sdk` uses `createRequire(import.meta.url)` to locate the `@sourcegraph/amp` package. In compiled binaries, `import.meta.url` points to the binary itself, so Node module resolution fails when the binary is not inside the amp-acp project tree.

2. **`Amp CLI process exited with code 1`** with stderr containing only ANSI terminal sequences (`\x1b[=0u\x1b[<u\x1b[?25h`) - The amp CLI native binary initializes kitty keyboard protocol when `TERM` env is set (e.g. `xterm-256color`), even when stdio is piped. Terminal cleanup on exit then writes to the pipe and fails.

## Fix

1. Added `scripts/patch-find-amp.ts` postbuild script that patches the bundled `findAmpCommand()` to fallback to `~/.amp/bin/amp` and system PATH when `createRequire` resolution fails.

2. Pass `env: { TERM: 'dumb' }` to `execute()` options to prevent amp CLI from initializing terminal UI features.

Updated `build`, `build:binary`, and `test:binary` scripts in package.json to include the patch step.