### PR TITLE
improve --setup prompt: show URL to get API key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ async function setup(): Promise<void> {
     process.exit(0);
   }
 
+  console.error('You can get your API key from: https://ampcode.com/settings');
   const apiKey = await prompt('Paste your AMP API key: ');
   if (!apiKey) {
     console.error('No API key provided. Aborting.');


### PR DESCRIPTION
Add a hint message pointing users to https://ampcode.com/settings before prompting for the API key during `--setup`.