### PR TITLE
feat: opt-in AMP_ACP_CONTINUE_LATEST to continue latest thread on first prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Requires Node.js 18+.
 - **`/init` command** — Type `/init` to generate an `AGENTS.md` file for your project
 - **Conversation continuity** — Thread context is preserved across multiple prompts within a session
 
+### Continuing the latest thread on session start
+
+When the environment variable `AMP_ACP_CONTINUE_LATEST=1` is set, the first prompt in a fresh ACP session will continue the most recent Amp thread on this installation (equivalent to `amp threads continue`) instead of starting a new one. Useful when the ACP session follows on from prior `amp` CLI activity (for example, a one-shot `amp -x` invocation) and you want the chat to inherit that context. Off by default.
+
 ## MCP Configuration Passthrough
 
 MCP servers configured in Zed's `context_servers` are automatically forwarded to Amp. This is compatible with how other ACP agents like [Claude Code](https://github.com/zed-industries/claude-code-acp) and [Codex](https://github.com/zed-industries/codex-acp) handle MCP servers.

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, beforeEach, afterEach, expect, mock } from 'bun:test';
+import type { AgentSideConnection } from '@agentclientprotocol/sdk';
+
+const capturedCalls: { options: Record<string, unknown> }[] = [];
+
+mock.module('@sourcegraph/amp-sdk', () => ({
+  execute: ({ options }: { options: Record<string, unknown> }) => {
+    capturedCalls.push({ options });
+    return (async function* () {
+      yield { type: 'system', subtype: 'init', session_id: 'T-test-thread-id' };
+      yield { type: 'result', subtype: 'success', is_error: false };
+    })();
+  },
+}));
+
+const { AmpAcpAgent } = await import('./server.js');
+
+const mockClient = {
+  sessionUpdate: async () => {},
+  readTextFile: async () => ({ text: '' }),
+  writeTextFile: async () => ({}),
+  requestPermission: async () => ({ optionId: '' }),
+  createTerminal: async () => ({ id: '' }),
+  extMethod: async () => ({}),
+  extNotification: async () => {},
+} as unknown as AgentSideConnection;
+
+describe('AmpAcpAgent prompt() continue option', () => {
+  let agent: InstanceType<typeof AmpAcpAgent>;
+  const originalEnv = process.env.AMP_ACP_CONTINUE_LATEST;
+
+  beforeEach(async () => {
+    capturedCalls.length = 0;
+    delete process.env.AMP_ACP_CONTINUE_LATEST;
+    agent = new AmpAcpAgent(mockClient);
+    await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AMP_ACP_CONTINUE_LATEST;
+    } else {
+      process.env.AMP_ACP_CONTINUE_LATEST = originalEnv;
+    }
+  });
+
+  it('does not set continue on first prompt when env var is unset (default)', async () => {
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]!.options.continue).toBeUndefined();
+  });
+
+  it('sets continue=true on first prompt when AMP_ACP_CONTINUE_LATEST is set', async () => {
+    process.env.AMP_ACP_CONTINUE_LATEST = '1';
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]!.options.continue).toBe(true);
+  });
+
+  it('passes captured threadId on subsequent prompts regardless of env var', async () => {
+    process.env.AMP_ACP_CONTINUE_LATEST = '1';
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'first' }],
+    });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'second' }],
+    });
+
+    expect(capturedCalls).toHaveLength(2);
+    expect(capturedCalls[0]!.options.continue).toBe(true);
+    expect(capturedCalls[1]!.options.continue).toBe('T-test-thread-id');
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -195,6 +195,9 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
 
     if (s.threadId) {
       options.continue = s.threadId;
+    } else if (process.env.AMP_ACP_CONTINUE_LATEST) {
+      options.continue = true;
+      console.error('[acp] AMP_ACP_CONTINUE_LATEST set; continuing latest thread on this installation');
     }
 
     const controller = new AbortController();


### PR DESCRIPTION
## Motivation

Adds support for using `amp` on ephemeral workstations and similar environments where an ACP session needs to continue from an initial one-shot prompt run via the `amp` CLI.

A common pattern in such setups: a workstation/container is provisioned, runs `amp -x 'some prompt'` as part of bootstrap to do initial work, then a user later opens an ACP-driven chat (e.g. in Zed) on the same machine. Today the chat session has no knowledge of the one-shot's thread — it always starts a brand-new thread, losing the bootstrap context.

## Change

When the environment variable `AMP_ACP_CONTINUE_LATEST` is set, the **first** prompt in a fresh ACP session sets `options.continue = true`, which causes the underlying amp invocation to continue the most recent thread on this installation (`installationID` from `~/.local/share/amp/device-id.json`).

Subsequent prompts in the same session continue using the captured thread ID, exactly as before.

Default behaviour is unchanged: with the env var unset, fresh sessions still start a new amp thread.

## Notes

- amp scopes "continue last" by `installationID`, not by API key, so this is safe even when an API key is shared across multiple installations — each installation only sees its own latest thread.
- Logging uses `console.error` to avoid corrupting the JSON-RPC wire on stdout (per AGENTS.md).
- `bun run lint` clean, `bun test src/` 37/37 pass (3 new tests added).