### PR TITLE
chore: align with Amp Neo release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This is an ACP (Agent Client Protocol) adapter that bridges Amp Code to ACP-comp
 
 - `src/index.ts` — Entry point, redirects console to stderr (stdout reserved for ACP stream)
 - `src/run-acp.ts` — Sets up ACP connection using stdin/stdout JSON streams
-- `src/server.ts` — `AmpAcpAgent` class: handles sessions, prompts, MCP config, and calls `@sourcegraph/amp-sdk`
+- `src/server.ts` — `AmpAcpAgent` class: handles sessions, prompts, MCP config, and calls `@ampcode/sdk` (formerly `@sourcegraph/amp-sdk`)
 - `src/to-acp.ts` — Converts Amp stream events to ACP `sessionUpdate` notifications
 - `src/mcp-config.ts` — Converts ACP MCP server configs to Amp SDK format
 - `src/utils.ts` — Node-to-Web stream converters

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Requires Node.js 18+.
 - **Streaming responses** — Amp messages, tool calls, and thinking are streamed in real-time via ACP
 - **Image support** — Handles image content blocks from Amp (base64 and URL)
 - **MCP passthrough** — MCP servers configured in Zed are automatically passed through to Amp
-- **Session modes** — Switch between *Default* (prompts for tool permissions) and *Bypass* (skips permission prompts)
+- **Session modes** — Switch between *Default* (uses Amp's configured behavior — since [Amp Neo](https://ampcode.com/news/neo) this means no prompts unless you've opted into the built-in permissions plugin via `amp.permissions`, `amp.dangerouslyAllowAll: false`, or `amp.guardedFiles.allowlist`) and *Bypass* (force-allow every tool call, overriding any configured permissions plugin)
 - **`/init` command** — Type `/init` to generate an `AGENTS.md` file for your project
 - **Conversation continuity** — Thread context is preserved across multiple prompts within a session
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "amp-acp",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.4.8",
-        "@sourcegraph/amp": "^0.0.1765685598-g5365e6",
-        "@sourcegraph/amp-sdk": "0.1.0-20260220044036-g88868e6",
+        "@ampcode/cli": "^0.0.1779624958-g6d0650",
+        "@ampcode/sdk": "0.1.0-20260524123501-g6d0650a",
       },
       "devDependencies": {
         "@types/bun": "^1.2.5",
@@ -18,35 +18,19 @@
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.4.8", "", { "dependencies": { "zod": "^3.0.0" } }, "sha512-2hN2CMMWtYVHrUeuapwLu66S2wwOPhq+bLqAryl1cQjKjL5Mzkfq+oxFYFvGdPvBoKpJSxM2pIIQiUH8tGZ3rg=="],
 
-    "@napi-rs/keyring": ["@napi-rs/keyring@1.1.9", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.1.9", "@napi-rs/keyring-darwin-x64": "1.1.9", "@napi-rs/keyring-freebsd-x64": "1.1.9", "@napi-rs/keyring-linux-arm-gnueabihf": "1.1.9", "@napi-rs/keyring-linux-arm64-gnu": "1.1.9", "@napi-rs/keyring-linux-arm64-musl": "1.1.9", "@napi-rs/keyring-linux-riscv64-gnu": "1.1.9", "@napi-rs/keyring-linux-x64-gnu": "1.1.9", "@napi-rs/keyring-linux-x64-musl": "1.1.9", "@napi-rs/keyring-win32-arm64-msvc": "1.1.9", "@napi-rs/keyring-win32-ia32-msvc": "1.1.9", "@napi-rs/keyring-win32-x64-msvc": "1.1.9" } }, "sha512-qjg04yaJ/gFqgG7wDqLlWBvZpsjvYDtwL+xOr2vSM2JrhojuIKsw7pH013U7xJOradTVGeQqhwqgZtt2IblgOw=="],
+    "@ampcode/cli": ["@ampcode/cli@0.0.1779624958-g6d0650", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1779624958-g6d0650", "@ampcode/cli-darwin-x64": "0.0.1779624958-g6d0650", "@ampcode/cli-linux-arm64": "0.0.1779624958-g6d0650", "@ampcode/cli-linux-x64": "0.0.1779624958-g6d0650", "@ampcode/cli-win32-x64": "0.0.1779624958-g6d0650" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-s+zoyyX1VlCySmXGVNpK3m9kaYqbnZIzlcQpSCrfw3P5AGnUpW6jrKd5n6Ge+UDI7G8/W389Bs8XY6iiNePmzg=="],
 
-    "@napi-rs/keyring-darwin-arm64": ["@napi-rs/keyring-darwin-arm64@1.1.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/lVnrSFrut+8pQC6IcqlfHKzcEmf2XvQDOZPB5X4vI23GrNXBd56EuBlFPdTBtx46A8Bn+Aqi6pS8cnprHtcCw=="],
+    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1779624958-g6d0650", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WyfmBBLsmWghkdDx+8liB2QjluKwH0jX2SG/H4H8sqRlPkrZwz3RXJS5d1wzLiEshvMIJJMuRTHuOG02SH9mDg=="],
 
-    "@napi-rs/keyring-darwin-x64": ["@napi-rs/keyring-darwin-x64@1.1.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-G3PiFZTAFTzUnpSB31A/UaPjl48/3sDTLmLxaAZBEk7HcOyBnL31gA1YqhDCO7F2y5sD5TWiFiuID9MyqYOcjw=="],
+    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1779624958-g6d0650", "", { "os": "darwin", "cpu": "x64" }, "sha512-qqbJOGK7sj/O03KLIGG8e+GHdzf7MlWJBfny0QzGkS+c4JE3K7j2lT5xnxNMrxOQr78hJbsc6loTyPVqak9+Dg=="],
 
-    "@napi-rs/keyring-freebsd-x64": ["@napi-rs/keyring-freebsd-x64@1.1.9", "", { "os": "freebsd", "cpu": "x64" }, "sha512-R4XbvRhEzQyOy4yM+SMDgk8BgkLPkIzXGwR6QR0wJ2YrPeBx3F2TrgdHfsIGSn/X5Axg/2UlrCiZVciZ5BmusA=="],
+    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1779624958-g6d0650", "", { "os": "linux", "cpu": "arm64" }, "sha512-XCcGM7HCmPDgYTVGxAc73OmUOdD6CsV4Xuwm6jSyW+CEpiDexYu3EP8jotxzGqT/YGAZQHSMsfJnjw1bT/88oQ=="],
 
-    "@napi-rs/keyring-linux-arm-gnueabihf": ["@napi-rs/keyring-linux-arm-gnueabihf@1.1.9", "", { "os": "linux", "cpu": "arm" }, "sha512-UrKy110I+zQyBtw4HLVUqZ1jDq11K3PmQIYgWAJNwB5VQOj4IQ63zLxk4V01Jx4bNOJmGNlvHDJUAyh/lC5Yww=="],
+    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1779624958-g6d0650", "", { "os": "linux", "cpu": "x64" }, "sha512-uqnfPDe4RoqRAkSuoRbzeRFI1KhGsA2QnevdskBFwJWwzjQ3Z/Yah+6WyBneWav0zRemc0C7PoPDn3eV3gyadg=="],
 
-    "@napi-rs/keyring-linux-arm64-gnu": ["@napi-rs/keyring-linux-arm64-gnu@1.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-yOrhVpNGexDYzybe3dhmHQRPBDjlZPtJDE+eGSi1JwEqYlWDB+4IWjRsetxnO63DhnMFRLeMTdwWghsYrA7VwA=="],
+    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1779624958-g6d0650", "", { "os": "win32", "cpu": "x64" }, "sha512-PXHOSMf1eairHiDWGXG48W3902H8qdj1VwOyNX/UYmIoQOpTpHzPINa1BJpg6Q+S7Enm4qeevVbW6Hx81CEH3A=="],
 
-    "@napi-rs/keyring-linux-arm64-musl": ["@napi-rs/keyring-linux-arm64-musl@1.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-82EcuzoV/+Dxwi1HHhrEEprN5Ou7OsRKyTJSaRqiVuGvLaQDUhZX/4zXTTh4Pz24m22Q4aoJogafS31w8iKGGw=="],
-
-    "@napi-rs/keyring-linux-riscv64-gnu": ["@napi-rs/keyring-linux-riscv64-gnu@1.1.9", "", { "os": "linux", "cpu": "none" }, "sha512-Q1ar7DszC1X8FW6w7Ql7b72GFeAUxkTiOuxXChCFBy7eWCQSDrr52ZLroIowp82RmkQLZebnK+IwSssD2Ntoag=="],
-
-    "@napi-rs/keyring-linux-x64-gnu": ["@napi-rs/keyring-linux-x64-gnu@1.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-LMvrYt1ho3pEDECssA7ATbcMDgayEUwwSD+UfrC7Hj1+C6dlvipwt5njwUDCno2OeXbjjisCo4CR9fDmXa4sZA=="],
-
-    "@napi-rs/keyring-linux-x64-musl": ["@napi-rs/keyring-linux-x64-musl@1.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-x2i/TgS2/fM+6LRj1MrtVC580sepz5GcxbSCXpttx2H58uZKBF0vVM9HDPHoKP2w5++fyrA17eltJNYN3Ob46A=="],
-
-    "@napi-rs/keyring-win32-arm64-msvc": ["@napi-rs/keyring-win32-arm64-msvc@1.1.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-14t6p8CTBNfGzLO5LXqurT+pAOf/ocGjOM/qiG/LW+jPkhyJYBNI9e3HKq3QX+ObbnxVpt4fAY02b4XLt7EWig=="],
-
-    "@napi-rs/keyring-win32-ia32-msvc": ["@napi-rs/keyring-win32-ia32-msvc@1.1.9", "", { "os": "win32", "cpu": "ia32" }, "sha512-7+7aXz5op6PtOnWYcK1GYXWQlk2zfpdPt9taLqmCCVpk1g4m3Gw1wyKyQxjrg9clHWdNhdWxhFEA0osDxG8/Eg=="],
-
-    "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@1.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-P1wsSrSqDqvcXLL7yiH2RsO3De65wuEQj1ZjV9s1MHfEP5dIdriNYZfFsRBlOsl32GoK3qFzsuH5DTVviGEHSw=="],
-
-    "@sourcegraph/amp": ["@sourcegraph/amp@0.0.1765685598-g5365e6", "", { "dependencies": { "@napi-rs/keyring": "1.1.9" }, "bin": { "amp": "dist/main.js" } }, "sha512-9BUK22SxjNme91EnHgCDKiIoe9EXxaNNBNgv86OaPs2d8cdqwQimL7oY8ufD7eRWdEndE6IXS6A7JitXnNQ1SA=="],
-
-    "@sourcegraph/amp-sdk": ["@sourcegraph/amp-sdk@0.1.0-20260220044036-g88868e6", "", { "dependencies": { "@sourcegraph/amp": "latest", "zod": "^3.23.8" } }, "sha512-lw2iyHwIONOYaWtPP3etI4p5Q1Oye3Xn7Pjr6S34fGq+AJ5RIq5fouddGYmSH7H1bWUIxyT2rtQU342xkwzZfw=="],
+    "@ampcode/sdk": ["@ampcode/sdk@0.1.0-20260524123501-g6d0650a", "", { "dependencies": { "zod": "^3.23.8" }, "bin": { "amp-sdk": "bin/amp-sdk.js" } }, "sha512-7qwGTuiXdc5uk5MDLapnZCSE6p4Wk64016I/vi8g5PhDjBFsjlG6uHqNCaN/a8dBaYRsvWJtJNFsXIh/zHz+nQ=="],
 
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
@@ -59,7 +43,5 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@sourcegraph/amp-sdk/@sourcegraph/amp": ["@sourcegraph/amp@0.0.1771561861-gb93d97", "", { "dependencies": { "@napi-rs/keyring": "1.1.9" }, "bin": { "amp": "dist/main.js" } }, "sha512-tSawLhtkKJaQ5NP6Gf2pNORMuQVpKSVmnK5bYNEtStzvezsXKUXStWhUBMRa1vvY6gEdsP51vPCSGjqaWHN0aQ=="],
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,23 @@
 {
   "name": "amp-acp",
-  "version": "0.4.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amp-acp",
-      "version": "0.4.2",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.4.8",
-        "@sourcegraph/amp": "^0.0.1765685598-g5365e6",
-        "@sourcegraph/amp-sdk": "^0.1.0-20251214200908-g3251f72"
+        "@ampcode/cli": "^0.0.1779624958-g6d0650",
+        "@ampcode/sdk": "0.1.0-20260524123501-g6d0650a"
       },
       "bin": {
         "amp-acp": "dist/index.js"
       },
       "devDependencies": {
         "@types/bun": "^1.2.5",
-        "bun-types": "^1.3.8",
         "typescript": "^5.9.3"
       }
     },
@@ -31,277 +30,133 @@
         "zod": "^3.0.0"
       }
     },
-    "node_modules/@napi-rs/keyring": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.1.9.tgz",
-      "integrity": "sha512-qjg04yaJ/gFqgG7wDqLlWBvZpsjvYDtwL+xOr2vSM2JrhojuIKsw7pH013U7xJOradTVGeQqhwqgZtt2IblgOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
+    "node_modules/@ampcode/cli": {
+      "version": "0.0.1779624958-g6d0650",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli/-/cli-0.0.1779624958-g6d0650.tgz",
+      "integrity": "sha512-s+zoyyX1VlCySmXGVNpK3m9kaYqbnZIzlcQpSCrfw3P5AGnUpW6jrKd5n6Ge+UDI7G8/W389Bs8XY6iiNePmzg==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "amp": "bin/amp.exe"
       },
       "optionalDependencies": {
-        "@napi-rs/keyring-darwin-arm64": "1.1.9",
-        "@napi-rs/keyring-darwin-x64": "1.1.9",
-        "@napi-rs/keyring-freebsd-x64": "1.1.9",
-        "@napi-rs/keyring-linux-arm-gnueabihf": "1.1.9",
-        "@napi-rs/keyring-linux-arm64-gnu": "1.1.9",
-        "@napi-rs/keyring-linux-arm64-musl": "1.1.9",
-        "@napi-rs/keyring-linux-riscv64-gnu": "1.1.9",
-        "@napi-rs/keyring-linux-x64-gnu": "1.1.9",
-        "@napi-rs/keyring-linux-x64-musl": "1.1.9",
-        "@napi-rs/keyring-win32-arm64-msvc": "1.1.9",
-        "@napi-rs/keyring-win32-ia32-msvc": "1.1.9",
-        "@napi-rs/keyring-win32-x64-msvc": "1.1.9"
+        "@ampcode/cli-darwin-arm64": "0.0.1779624958-g6d0650",
+        "@ampcode/cli-darwin-x64": "0.0.1779624958-g6d0650",
+        "@ampcode/cli-linux-arm64": "0.0.1779624958-g6d0650",
+        "@ampcode/cli-linux-x64": "0.0.1779624958-g6d0650",
+        "@ampcode/cli-win32-x64": "0.0.1779624958-g6d0650"
       }
     },
-    "node_modules/@napi-rs/keyring-darwin-arm64": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.1.9.tgz",
-      "integrity": "sha512-/lVnrSFrut+8pQC6IcqlfHKzcEmf2XvQDOZPB5X4vI23GrNXBd56EuBlFPdTBtx46A8Bn+Aqi6pS8cnprHtcCw==",
+    "node_modules/@ampcode/cli-darwin-arm64": {
+      "version": "0.0.1779624958-g6d0650",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-arm64/-/cli-darwin-arm64-0.0.1779624958-g6d0650.tgz",
+      "integrity": "sha512-WyfmBBLsmWghkdDx+8liB2QjluKwH0jX2SG/H4H8sqRlPkrZwz3RXJS5d1wzLiEshvMIJJMuRTHuOG02SH9mDg==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@napi-rs/keyring-darwin-x64": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.1.9.tgz",
-      "integrity": "sha512-G3PiFZTAFTzUnpSB31A/UaPjl48/3sDTLmLxaAZBEk7HcOyBnL31gA1YqhDCO7F2y5sD5TWiFiuID9MyqYOcjw==",
+    "node_modules/@ampcode/cli-darwin-x64": {
+      "version": "0.0.1779624958-g6d0650",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-x64/-/cli-darwin-x64-0.0.1779624958-g6d0650.tgz",
+      "integrity": "sha512-qqbJOGK7sj/O03KLIGG8e+GHdzf7MlWJBfny0QzGkS+c4JE3K7j2lT5xnxNMrxOQr78hJbsc6loTyPVqak9+Dg==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@napi-rs/keyring-freebsd-x64": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.1.9.tgz",
-      "integrity": "sha512-R4XbvRhEzQyOy4yM+SMDgk8BgkLPkIzXGwR6QR0wJ2YrPeBx3F2TrgdHfsIGSn/X5Axg/2UlrCiZVciZ5BmusA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.1.9.tgz",
-      "integrity": "sha512-UrKy110I+zQyBtw4HLVUqZ1jDq11K3PmQIYgWAJNwB5VQOj4IQ63zLxk4V01Jx4bNOJmGNlvHDJUAyh/lC5Yww==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.1.9.tgz",
-      "integrity": "sha512-yOrhVpNGexDYzybe3dhmHQRPBDjlZPtJDE+eGSi1JwEqYlWDB+4IWjRsetxnO63DhnMFRLeMTdwWghsYrA7VwA==",
+    "node_modules/@ampcode/cli-linux-arm64": {
+      "version": "0.0.1779624958-g6d0650",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-arm64/-/cli-linux-arm64-0.0.1779624958-g6d0650.tgz",
+      "integrity": "sha512-XCcGM7HCmPDgYTVGxAc73OmUOdD6CsV4Xuwm6jSyW+CEpiDexYu3EP8jotxzGqT/YGAZQHSMsfJnjw1bT/88oQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.1.9.tgz",
-      "integrity": "sha512-82EcuzoV/+Dxwi1HHhrEEprN5Ou7OsRKyTJSaRqiVuGvLaQDUhZX/4zXTTh4Pz24m22Q4aoJogafS31w8iKGGw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.1.9.tgz",
-      "integrity": "sha512-Q1ar7DszC1X8FW6w7Ql7b72GFeAUxkTiOuxXChCFBy7eWCQSDrr52ZLroIowp82RmkQLZebnK+IwSssD2Ntoag==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.1.9.tgz",
-      "integrity": "sha512-LMvrYt1ho3pEDECssA7ATbcMDgayEUwwSD+UfrC7Hj1+C6dlvipwt5njwUDCno2OeXbjjisCo4CR9fDmXa4sZA==",
+    "node_modules/@ampcode/cli-linux-x64": {
+      "version": "0.0.1779624958-g6d0650",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-x64/-/cli-linux-x64-0.0.1779624958-g6d0650.tgz",
+      "integrity": "sha512-uqnfPDe4RoqRAkSuoRbzeRFI1KhGsA2QnevdskBFwJWwzjQ3Z/Yah+6WyBneWav0zRemc0C7PoPDn3eV3gyadg==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@napi-rs/keyring-linux-x64-musl": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.1.9.tgz",
-      "integrity": "sha512-x2i/TgS2/fM+6LRj1MrtVC580sepz5GcxbSCXpttx2H58uZKBF0vVM9HDPHoKP2w5++fyrA17eltJNYN3Ob46A==",
+    "node_modules/@ampcode/cli-win32-x64": {
+      "version": "0.0.1779624958-g6d0650",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-win32-x64/-/cli-win32-x64-0.0.1779624958-g6d0650.tgz",
+      "integrity": "sha512-PXHOSMf1eairHiDWGXG48W3902H8qdj1VwOyNX/UYmIoQOpTpHzPINa1BJpg6Q+S7Enm4qeevVbW6Hx81CEH3A==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.1.9.tgz",
-      "integrity": "sha512-14t6p8CTBNfGzLO5LXqurT+pAOf/ocGjOM/qiG/LW+jPkhyJYBNI9e3HKq3QX+ObbnxVpt4fAY02b4XLt7EWig==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.1.9.tgz",
-      "integrity": "sha512-7+7aXz5op6PtOnWYcK1GYXWQlk2zfpdPt9taLqmCCVpk1g4m3Gw1wyKyQxjrg9clHWdNhdWxhFEA0osDxG8/Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.1.9.tgz",
-      "integrity": "sha512-P1wsSrSqDqvcXLL7yiH2RsO3De65wuEQj1ZjV9s1MHfEP5dIdriNYZfFsRBlOsl32GoK3qFzsuH5DTVviGEHSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@sourcegraph/amp": {
-      "version": "0.0.1765685598-g5365e6",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1765685598-g5365e6.tgz",
-      "integrity": "sha512-9BUK22SxjNme91EnHgCDKiIoe9EXxaNNBNgv86OaPs2d8cdqwQimL7oY8ufD7eRWdEndE6IXS6A7JitXnNQ1SA==",
+    "node_modules/@ampcode/sdk": {
+      "version": "0.1.0-20260524123501-g6d0650a",
+      "resolved": "https://registry.npmjs.org/@ampcode/sdk/-/sdk-0.1.0-20260524123501-g6d0650a.tgz",
+      "integrity": "sha512-7qwGTuiXdc5uk5MDLapnZCSE6p4Wk64016I/vi8g5PhDjBFsjlG6uHqNCaN/a8dBaYRsvWJtJNFsXIh/zHz+nQ==",
       "license": "Amp Commercial License",
       "dependencies": {
-        "@napi-rs/keyring": "1.1.9"
+        "zod": "^3.23.8"
       },
       "bin": {
-        "amp": "dist/main.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@sourcegraph/amp-sdk": {
-      "version": "0.1.0-20251214200908-g3251f72",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/amp-sdk/-/amp-sdk-0.1.0-20251214200908-g3251f72.tgz",
-      "integrity": "sha512-5Tef+Jb43agvAsfcC3nvMNuGcj2I/qooNfYiyQTbgSpyUFoYC7as6gETOE44HSTN17ovmRqU/jgimsN+8UJ6Wg==",
-      "license": "Amp Commercial License",
-      "dependencies": {
-        "@sourcegraph/amp": "latest",
-        "zod": "^3.23.8"
+        "amp-sdk": "bin/amp-sdk.js"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@types/bun": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.8.tgz",
-      "integrity": "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bun-types": "1.3.8"
+        "bun-types": "1.3.14"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
-      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/bun-types": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.8.tgz",
-      "integrity": "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -323,9 +178,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.4.8",
-    "@sourcegraph/amp": "^0.0.1765685598-g5365e6",
-    "@sourcegraph/amp-sdk": "0.1.0-20260220044036-g88868e6"
+    "@ampcode/cli": "^0.0.1779624958-g6d0650",
+    "@ampcode/sdk": "0.1.0-20260524123501-g6d0650a"
   },
   "devDependencies": {
     "@types/bun": "^1.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,33 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import readline from 'node:readline';
+import { createRequire } from 'node:module';
 import { runAcp } from './run-acp.js';
+
+// Workaround for @ampcode/sdk: its findAmpCommand() resolves @ampcode/cli's
+// pkg.bin.amp ("bin/amp.exe") and then spawns it via `node <path>`. But the
+// new @ampcode/cli package replaces that stub with a native executable during
+// postinstall, so `node bin/amp.exe` blows up with ERR_UNKNOWN_FILE_EXTENSION.
+// Resolving the binary here and exposing it via AMP_CLI_PATH makes the SDK's
+// resolveCliFromEnvironment win (and it spawns non-.js paths directly).
+function preferBundledAmpCliBinary(): void {
+  if (process.env.AMP_CLI_PATH) return;
+  try {
+    const req = createRequire(import.meta.url);
+    for (const pkg of ['@ampcode/cli', '@sourcegraph/amp']) {
+      try {
+        const pkgJsonPath = req.resolve(`${pkg}/package.json`);
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')) as { bin?: { amp?: string } };
+        if (!pkgJson.bin?.amp) continue;
+        const binPath = path.resolve(path.dirname(pkgJsonPath), pkgJson.bin.amp);
+        if (!fs.existsSync(binPath)) continue;
+        if (binPath.endsWith('.js') || binPath.endsWith('.mjs') || binPath.endsWith('.cjs')) continue;
+        process.env.AMP_CLI_PATH = binPath;
+        return;
+      } catch { /* try next */ }
+    }
+  } catch { /* fall through; SDK will try PATH / ~/.local/share/amp */ }
+}
 
 function getConfigDir(): string {
   if (process.platform === 'win32') {
@@ -74,6 +100,8 @@ if (process.argv.includes('--setup')) {
       process.env.AMP_API_KEY = stored;
     }
   }
+
+  preferBundledAmpCliBinary();
 
   runAcp();
 

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -3,7 +3,7 @@ import type { AgentSideConnection } from '@agentclientprotocol/sdk';
 
 const capturedCalls: { options: Record<string, unknown> }[] = [];
 
-mock.module('@sourcegraph/amp-sdk', () => ({
+mock.module('@ampcode/sdk', () => ({
   execute: ({ options }: { options: Record<string, unknown> }) => {
     capturedCalls.push({ options });
     return (async function* () {

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,7 @@ import {
   type WriteTextFileResponse,
   type ClientCapabilities,
 } from '@agentclientprotocol/sdk';
-import { execute, type StreamMessage } from '@sourcegraph/amp-sdk';
+import { execute, type StreamMessage } from '@ampcode/sdk';
 import { convertAcpMcpServersToAmpConfig, type AmpMcpConfig } from './mcp-config.js';
 import { toAcpNotifications } from './to-acp.js';
 import path from 'node:path';
@@ -107,8 +107,17 @@ export class AmpAcpAgent implements Agent {
       modes: {
         currentModeId: 'default',
         availableModes: [
-          { id: 'default', name: 'Default', description: 'Prompts for permission on first use of each tool' },
-          { id: 'bypass', name: 'Bypass', description: 'Skips all permission prompts' },
+          {
+            id: 'default',
+            name: 'Default',
+            description:
+              "Use Amp's configured behavior. As of Amp Neo, tools run without prompts unless you've opted into permissions (e.g. amp.permissions, amp.dangerouslyAllowAll: false, or amp.guardedFiles.allowlist).",
+          },
+          {
+            id: 'bypass',
+            name: 'Bypass',
+            description: 'Force-allow every tool call, overriding any configured permissions plugin (dangerouslyAllowAll).',
+          },
         ],
       },
     };


### PR DESCRIPTION
Align amp-acp with the [Amp Neo release](https://ampcode.com/news/neo) (2026-05-06) and the [upcoming npm package rename](https://ampcode.com/news/npm-package-changes) (legacy aliases removed on **2026-06-15**).

## Changes

### 1. SDK upgrade + package rename
- Bump `@sourcegraph/amp-sdk` (Feb 2026) → `@ampcode/sdk@0.1.0-20260524123501-g6d0650a` (post-Neo).
- The new SDK no longer pulls in the CLI transitively, so `@ampcode/cli@^0.0.1779624958-g6d0650` is now an explicit dependency.
- Source import in `src/server.ts` and the test mock in `src/prompt-continue.test.ts` updated to use `@ampcode/sdk`.
- `bun.lock` / `package-lock.json` regenerated.

### 2. Session mode descriptions aligned with Neo

> "Amp will no longer ask for permission before running tools. What was once the `--dangerously-allow-all` flag is now the default behavior."

The previous descriptions were misleading:
- `default`: was "Prompts for permission on first use of each tool" — Neo no longer does that.
- `bypass`: was "Skips all permission prompts" — now redundant unless the user has opted into the built-in permissions plugin.

The IDs are kept (`default` / `bypass`) for backward compatibility with Zed's persisted mode selection, but the descriptions now accurately reflect what each mode does under Neo. `bypass` continues to set `dangerouslyAllowAll: true`, so it still meaningfully overrides any configured permissions plugin.

### 3. Docs
- README.md "Session modes" entry rewritten and linked to the Neo announcement.
- AGENTS.md updated with the new SDK package name.

## Verification
- `bun run lint` ✅
- `bun test src/` ✅ (37 pass)
- `bun run build` ✅
