### PR TITLE
Improve tool call rendering

### DIFF
--- a/src/acp-protocol.test.ts
+++ b/src/acp-protocol.test.ts
@@ -214,9 +214,52 @@ describe('toAcpNotifications', () => {
     expect(result[0].update).toMatchObject({
       sessionUpdate: 'tool_call',
       toolCallId: 'tool-1',
-      title: 'Read',
+      title: 'Read: /tmp/file.txt',
       status: 'pending',
-      kind: 'other',
+      kind: 'read',
+      locations: [{ path: '/tmp/file.txt' }],
+    });
+  });
+
+  it('should render Bash tool calls with the command', () => {
+    const result = toAcpNotifications(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'tool-2', name: 'Bash', input: { cmd: 'rg "tool_call" src' } }],
+        },
+      },
+      'session-1',
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].update).toMatchObject({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'tool-2',
+      title: 'Bash: rg "tool_call" src',
+      status: 'pending',
+      kind: 'execute',
+    });
+  });
+
+  it('should render nested Bash commands in tool title', () => {
+    const result = toAcpNotifications(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'tool-2b', name: 'Bash', input: { input: { command: 'uptime' } } }],
+        },
+      },
+      'session-1',
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].update).toMatchObject({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'tool-2b',
+      title: 'Bash: uptime',
+      status: 'pending',
+      kind: 'execute',
     });
   });
 
@@ -294,7 +337,7 @@ describe('toAcpNotifications', () => {
     expect(result).toHaveLength(3);
     expect(result[0].update).toMatchObject({ sessionUpdate: 'agent_thought_chunk' });
     expect(result[1].update).toMatchObject({ sessionUpdate: 'agent_message_chunk' });
-    expect(result[2].update).toMatchObject({ sessionUpdate: 'tool_call', title: 'Bash' });
+    expect(result[2].update).toMatchObject({ sessionUpdate: 'tool_call', title: 'Bash: ls' });
   });
 
   it('should return empty for missing message', () => {

--- a/src/to-acp.ts
+++ b/src/to-acp.ts
@@ -1,4 +1,10 @@
-import type { SessionNotification, ContentBlock, ToolCallContent } from '@agentclientprotocol/sdk';
+import type {
+  SessionNotification,
+  ContentBlock,
+  ToolCallContent,
+  ToolCallLocation,
+  ToolKind,
+} from '@agentclientprotocol/sdk';
 
 interface AmpContentText {
   type: 'text';
@@ -86,15 +92,19 @@ export function toAcpNotifications(message: AmpMessage, sessionId: string): Sess
         };
         break;
       case 'tool_use':
-        update = {
-          toolCallId: chunk.id,
-          sessionUpdate: 'tool_call' as const,
-          rawInput: safeJson(chunk.input),
-          status: 'pending' as const,
-          title: chunk.name || 'Tool',
-          kind: 'other' as const,
-          content: [],
-        };
+        {
+          const metadata = toolCallMetadata(chunk.name, chunk.input);
+          update = {
+            toolCallId: chunk.id,
+            sessionUpdate: 'tool_call' as const,
+            rawInput: safeJson(chunk.input),
+            status: 'pending' as const,
+            title: metadata.title,
+            kind: metadata.kind,
+            locations: metadata.locations.length > 0 ? metadata.locations : undefined,
+            content: [],
+          };
+        }
         break;
       case 'tool_result':
         update = {
@@ -127,6 +137,176 @@ function toAcpContentArray(content: string | AmpContentText[], isError = false):
 
 function wrapCode(t: string): string {
   return '```\n' + t + '\n```';
+}
+
+interface ToolCallMetadata {
+  title: string;
+  kind: ToolKind;
+  locations: ToolCallLocation[];
+}
+
+function toolCallMetadata(name: string, input: unknown): ToolCallMetadata {
+  const toolName = name || 'Tool';
+  const args = isRecord(input) ? input : {};
+  const title = toolCallTitle(toolName, args);
+
+  return {
+    title,
+    kind: toolKind(toolName),
+    locations: toolCallLocations(toolName, args),
+  };
+}
+
+function toolCallTitle(name: string, input: Record<string, unknown>): string {
+  const command = commandValue(input);
+  const path = firstString(input, ['path', 'file_path', 'notebook_path']);
+  const pattern = stringValue(input.pattern);
+  const url = stringValue(input.url);
+
+  switch (name) {
+    case 'Bash':
+      return withDetail(name, command);
+    case 'Read':
+      return withDetail(name, path);
+    case 'Write':
+      return withDetail(name, path);
+    case 'Edit':
+    case 'MultiEdit':
+      return withDetail(name, path);
+    case 'Glob':
+      return withDetail(name, pattern ?? path);
+    case 'Grep':
+      return withDetail(name, pattern ?? path);
+    case 'LS':
+      return withDetail('List', path);
+    case 'WebFetch':
+      return withDetail(name, url);
+    case 'TodoWrite':
+      return 'Update todo list';
+    case 'Task':
+      return withDetail(name, stringValue(input.description) ?? stringValue(input.subagent_type));
+    default:
+      return withDetail(name, firstScalarString(input));
+  }
+}
+
+function commandValue(input: Record<string, unknown>): string | undefined {
+  return (
+    commandSegmentValue(input.cmd) ??
+    commandSegmentValue(input.command) ??
+    firstString(input, ['shell_command', 'shellCommand', 'script']) ??
+    nestedCommandValue(input, 0)
+  );
+}
+
+function commandSegmentValue(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (!Array.isArray(value)) return undefined;
+  const parts = value
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+function nestedCommandValue(value: unknown, depth: number): string | undefined {
+  if (!isRecord(value) || depth > 2) return undefined;
+  const direct = commandSegmentValue(value.cmd) ?? commandSegmentValue(value.command);
+  if (direct) return direct;
+
+  for (const child of Object.values(value)) {
+    if (!isRecord(child)) continue;
+    const nested = nestedCommandValue(child, depth + 1);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+function toolKind(name: string): ToolKind {
+  switch (name) {
+    case 'Read':
+    case 'LS':
+      return 'read';
+    case 'Write':
+    case 'Edit':
+    case 'MultiEdit':
+      return 'edit';
+    case 'Glob':
+    case 'Grep':
+      return 'search';
+    case 'Bash':
+      return 'execute';
+    case 'WebFetch':
+      return 'fetch';
+    case 'TodoWrite':
+    case 'Task':
+      return 'think';
+    default:
+      return name.startsWith('mcp__') ? 'fetch' : 'other';
+  }
+}
+
+function toolCallLocations(name: string, input: Record<string, unknown>): ToolCallLocation[] {
+  const path = firstString(input, ['path', 'file_path', 'notebook_path']);
+  if (!path) return [];
+
+  switch (name) {
+    case 'Read':
+    case 'Write':
+    case 'Edit':
+    case 'MultiEdit':
+    case 'LS':
+    case 'Grep':
+    case 'Glob': {
+      const line = numberValue(input.line) ?? numberValue(input.offset);
+      return line === undefined ? [{ path }] : [{ path, line }];
+    }
+    default:
+      return [];
+  }
+}
+
+function withDetail(name: string, detail: string | undefined): string {
+  if (!detail) return name;
+  return `${name}: ${truncateSingleLine(detail, 120)}`;
+}
+
+function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = stringValue(input[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function firstScalarString(input: Record<string, unknown>): string | undefined {
+  for (const value of Object.values(input)) {
+    const string = stringValue(value) ?? numberValue(value)?.toString() ?? booleanValue(value)?.toString();
+    if (string) return string;
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function truncateSingleLine(value: string, maxLength: number): string {
+  const singleLine = value.replace(/\s+/g, ' ').trim();
+  if (singleLine.length <= maxLength) return singleLine;
+  return `${singleLine.slice(0, maxLength - 1)}…`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function safeJson(x: unknown): { [k: string]: unknown } | undefined {


### PR DESCRIPTION
## Summary
- render tool call titles with useful details such as paths, commands, patterns, and URLs
- map known Amp tools to ACP tool kinds and locations
- add protocol tests for enriched Read and Bash tool call rendering



Closes #17


<img width="2230" height="2882" alt="image" src="https://github.com/user-attachments/assets/0c9ea32c-3c58-411f-8483-d7252bb98c5c" />


## Testing
- bun test src/
- bun run lint