### PR TITLE
chore: release 0.8.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "amp-acp",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.4.8",
-        "@ampcode/cli": "^0.0.1779624958-g6d0650",
-        "@ampcode/sdk": "0.1.0-20260524123501-g6d0650a",
+        "@ampcode/cli": "^0.0.1779896748-g596c49",
+        "@ampcode/sdk": "0.1.0-20260528044221-ge0e19fa",
       },
       "devDependencies": {
         "@types/bun": "^1.2.5",
@@ -18,19 +18,19 @@
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.4.8", "", { "dependencies": { "zod": "^3.0.0" } }, "sha512-2hN2CMMWtYVHrUeuapwLu66S2wwOPhq+bLqAryl1cQjKjL5Mzkfq+oxFYFvGdPvBoKpJSxM2pIIQiUH8tGZ3rg=="],
 
-    "@ampcode/cli": ["@ampcode/cli@0.0.1779624958-g6d0650", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1779624958-g6d0650", "@ampcode/cli-darwin-x64": "0.0.1779624958-g6d0650", "@ampcode/cli-linux-arm64": "0.0.1779624958-g6d0650", "@ampcode/cli-linux-x64": "0.0.1779624958-g6d0650", "@ampcode/cli-win32-x64": "0.0.1779624958-g6d0650" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-s+zoyyX1VlCySmXGVNpK3m9kaYqbnZIzlcQpSCrfw3P5AGnUpW6jrKd5n6Ge+UDI7G8/W389Bs8XY6iiNePmzg=="],
+    "@ampcode/cli": ["@ampcode/cli@0.0.1779896748-g596c49", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1779896748-g596c49", "@ampcode/cli-darwin-x64": "0.0.1779896748-g596c49", "@ampcode/cli-linux-arm64": "0.0.1779896748-g596c49", "@ampcode/cli-linux-x64": "0.0.1779896748-g596c49", "@ampcode/cli-win32-x64": "0.0.1779896748-g596c49" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-kXCUoVEBmBl7EXztEPvZJxYubQj57oKGqY34kKQsbXYAl0sCbSSGmwBCSLI08gdK3yJClFgsZyz5VInjvbIKLg=="],
 
-    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1779624958-g6d0650", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WyfmBBLsmWghkdDx+8liB2QjluKwH0jX2SG/H4H8sqRlPkrZwz3RXJS5d1wzLiEshvMIJJMuRTHuOG02SH9mDg=="],
+    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1779896748-g596c49", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yl9oasAceWZeZB9WMt6nbbAkX/DiiLhM9OxkF6LiUkxTsyW/vUbecgAQsc+liPsXsd9tvbEx0D/J0A9mQsUIgQ=="],
 
-    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1779624958-g6d0650", "", { "os": "darwin", "cpu": "x64" }, "sha512-qqbJOGK7sj/O03KLIGG8e+GHdzf7MlWJBfny0QzGkS+c4JE3K7j2lT5xnxNMrxOQr78hJbsc6loTyPVqak9+Dg=="],
+    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1779896748-g596c49", "", { "os": "darwin", "cpu": "x64" }, "sha512-U35NdQXxY1HApqbnmbyoykjjcIlylE/eOe/ZdCTIAe3SdWByHxFHYy6+EzrprwpuSXk6YWJ6cLXu9DEro11XgA=="],
 
-    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1779624958-g6d0650", "", { "os": "linux", "cpu": "arm64" }, "sha512-XCcGM7HCmPDgYTVGxAc73OmUOdD6CsV4Xuwm6jSyW+CEpiDexYu3EP8jotxzGqT/YGAZQHSMsfJnjw1bT/88oQ=="],
+    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1779896748-g596c49", "", { "os": "linux", "cpu": "arm64" }, "sha512-UA26xFK6qyxgNn3VWaGxCGgKEN5gKcUHhEZwC6lbSz6soY/KVlWeJAmcRKfIcl6+393x7kR8S0OjBxQtyCBYHw=="],
 
-    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1779624958-g6d0650", "", { "os": "linux", "cpu": "x64" }, "sha512-uqnfPDe4RoqRAkSuoRbzeRFI1KhGsA2QnevdskBFwJWwzjQ3Z/Yah+6WyBneWav0zRemc0C7PoPDn3eV3gyadg=="],
+    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1779896748-g596c49", "", { "os": "linux", "cpu": "x64" }, "sha512-qbEBgXBsqQ2njNIFtFgvUEnw1EsgBgYZVNBlOUrkV8o4X//9jvPVRD5yI2oqVLXb2IG9q6fhEcu3N54nBbM1CA=="],
 
-    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1779624958-g6d0650", "", { "os": "win32", "cpu": "x64" }, "sha512-PXHOSMf1eairHiDWGXG48W3902H8qdj1VwOyNX/UYmIoQOpTpHzPINa1BJpg6Q+S7Enm4qeevVbW6Hx81CEH3A=="],
+    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1779896748-g596c49", "", { "os": "win32", "cpu": "x64" }, "sha512-OB76DHMOL2Kc1d2EaOPdNWOhHLbySF8hZ5QPvBECjUIBhFwq5VYyav6l26aBlc19Uiag2uTg8S7F12rHH/UEXw=="],
 
-    "@ampcode/sdk": ["@ampcode/sdk@0.1.0-20260524123501-g6d0650a", "", { "dependencies": { "zod": "^3.23.8" }, "bin": { "amp-sdk": "bin/amp-sdk.js" } }, "sha512-7qwGTuiXdc5uk5MDLapnZCSE6p4Wk64016I/vi8g5PhDjBFsjlG6uHqNCaN/a8dBaYRsvWJtJNFsXIh/zHz+nQ=="],
+    "@ampcode/sdk": ["@ampcode/sdk@0.1.0-20260528044221-ge0e19fa", "", { "dependencies": { "@ampcode/cli": "0.0.1779896748-g596c49", "zod": "^3.23.8" }, "bin": { "amp-sdk": "bin/amp-sdk.js" } }, "sha512-yRlzNLfhB1esLNU2+tOToJU47JX/sJ1pnPp5I6jmckgDvVa8qAif2+Tzk07fq7fzHoALkTRsit50Psp/ADBrng=="],
 
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "amp-acp"
 name = "Amp"
-version = "0.7.0"
+version = "0.8.0"
 schema_version = 1
 authors = ["tao12345666333"]
 description = "Amp Agent for Zed"
@@ -12,21 +12,21 @@ icon = "icon/amp.svg"
 
 
 [agent_servers.amp.targets.darwin-aarch64]
-archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-darwin-aarch64.tar.gz"
+archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-darwin-aarch64.tar.gz"
 cmd = "amp-acp"
 
 [agent_servers.amp.targets.darwin-x86_64]
-archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-darwin-x86_64.tar.gz"
+archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-darwin-x86_64.tar.gz"
 cmd = "amp-acp"
 
 [agent_servers.amp.targets.linux-aarch64]
-archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-linux-aarch64.tar.gz"
+archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-linux-aarch64.tar.gz"
 cmd = "amp-acp"
 
 [agent_servers.amp.targets.linux-x86_64]
-archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-linux-x86_64.tar.gz"
+archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-linux-x86_64.tar.gz"
 cmd = "amp-acp"
 
 [agent_servers.amp.targets.windows-x86_64]
-archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-windows-x86_64.zip"
+archive = "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-windows-x86_64.zip"
 cmd = "amp-acp.exe"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.4.8",
-        "@ampcode/cli": "^0.0.1779624958-g6d0650",
-        "@ampcode/sdk": "0.1.0-20260524123501-g6d0650a"
+        "@ampcode/cli": "^0.0.1779896748-g596c49",
+        "@ampcode/sdk": "0.1.0-20260528044221-ge0e19fa"
       },
       "bin": {
         "amp-acp": "dist/index.js"
@@ -31,26 +31,26 @@
       }
     },
     "node_modules/@ampcode/cli": {
-      "version": "0.0.1779624958-g6d0650",
-      "resolved": "https://registry.npmjs.org/@ampcode/cli/-/cli-0.0.1779624958-g6d0650.tgz",
-      "integrity": "sha512-s+zoyyX1VlCySmXGVNpK3m9kaYqbnZIzlcQpSCrfw3P5AGnUpW6jrKd5n6Ge+UDI7G8/W389Bs8XY6iiNePmzg==",
+      "version": "0.0.1779896748-g596c49",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli/-/cli-0.0.1779896748-g596c49.tgz",
+      "integrity": "sha512-kXCUoVEBmBl7EXztEPvZJxYubQj57oKGqY34kKQsbXYAl0sCbSSGmwBCSLI08gdK3yJClFgsZyz5VInjvbIKLg==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "amp": "bin/amp.exe"
       },
       "optionalDependencies": {
-        "@ampcode/cli-darwin-arm64": "0.0.1779624958-g6d0650",
-        "@ampcode/cli-darwin-x64": "0.0.1779624958-g6d0650",
-        "@ampcode/cli-linux-arm64": "0.0.1779624958-g6d0650",
-        "@ampcode/cli-linux-x64": "0.0.1779624958-g6d0650",
-        "@ampcode/cli-win32-x64": "0.0.1779624958-g6d0650"
+        "@ampcode/cli-darwin-arm64": "0.0.1779896748-g596c49",
+        "@ampcode/cli-darwin-x64": "0.0.1779896748-g596c49",
+        "@ampcode/cli-linux-arm64": "0.0.1779896748-g596c49",
+        "@ampcode/cli-linux-x64": "0.0.1779896748-g596c49",
+        "@ampcode/cli-win32-x64": "0.0.1779896748-g596c49"
       }
     },
     "node_modules/@ampcode/cli-darwin-arm64": {
-      "version": "0.0.1779624958-g6d0650",
-      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-arm64/-/cli-darwin-arm64-0.0.1779624958-g6d0650.tgz",
-      "integrity": "sha512-WyfmBBLsmWghkdDx+8liB2QjluKwH0jX2SG/H4H8sqRlPkrZwz3RXJS5d1wzLiEshvMIJJMuRTHuOG02SH9mDg==",
+      "version": "0.0.1779896748-g596c49",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-arm64/-/cli-darwin-arm64-0.0.1779896748-g596c49.tgz",
+      "integrity": "sha512-yl9oasAceWZeZB9WMt6nbbAkX/DiiLhM9OxkF6LiUkxTsyW/vUbecgAQsc+liPsXsd9tvbEx0D/J0A9mQsUIgQ==",
       "cpu": [
         "arm64"
       ],
@@ -61,9 +61,9 @@
       ]
     },
     "node_modules/@ampcode/cli-darwin-x64": {
-      "version": "0.0.1779624958-g6d0650",
-      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-x64/-/cli-darwin-x64-0.0.1779624958-g6d0650.tgz",
-      "integrity": "sha512-qqbJOGK7sj/O03KLIGG8e+GHdzf7MlWJBfny0QzGkS+c4JE3K7j2lT5xnxNMrxOQr78hJbsc6loTyPVqak9+Dg==",
+      "version": "0.0.1779896748-g596c49",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-x64/-/cli-darwin-x64-0.0.1779896748-g596c49.tgz",
+      "integrity": "sha512-U35NdQXxY1HApqbnmbyoykjjcIlylE/eOe/ZdCTIAe3SdWByHxFHYy6+EzrprwpuSXk6YWJ6cLXu9DEro11XgA==",
       "cpu": [
         "x64"
       ],
@@ -74,9 +74,9 @@
       ]
     },
     "node_modules/@ampcode/cli-linux-arm64": {
-      "version": "0.0.1779624958-g6d0650",
-      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-arm64/-/cli-linux-arm64-0.0.1779624958-g6d0650.tgz",
-      "integrity": "sha512-XCcGM7HCmPDgYTVGxAc73OmUOdD6CsV4Xuwm6jSyW+CEpiDexYu3EP8jotxzGqT/YGAZQHSMsfJnjw1bT/88oQ==",
+      "version": "0.0.1779896748-g596c49",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-arm64/-/cli-linux-arm64-0.0.1779896748-g596c49.tgz",
+      "integrity": "sha512-UA26xFK6qyxgNn3VWaGxCGgKEN5gKcUHhEZwC6lbSz6soY/KVlWeJAmcRKfIcl6+393x7kR8S0OjBxQtyCBYHw==",
       "cpu": [
         "arm64"
       ],
@@ -90,9 +90,9 @@
       ]
     },
     "node_modules/@ampcode/cli-linux-x64": {
-      "version": "0.0.1779624958-g6d0650",
-      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-x64/-/cli-linux-x64-0.0.1779624958-g6d0650.tgz",
-      "integrity": "sha512-uqnfPDe4RoqRAkSuoRbzeRFI1KhGsA2QnevdskBFwJWwzjQ3Z/Yah+6WyBneWav0zRemc0C7PoPDn3eV3gyadg==",
+      "version": "0.0.1779896748-g596c49",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-x64/-/cli-linux-x64-0.0.1779896748-g596c49.tgz",
+      "integrity": "sha512-qbEBgXBsqQ2njNIFtFgvUEnw1EsgBgYZVNBlOUrkV8o4X//9jvPVRD5yI2oqVLXb2IG9q6fhEcu3N54nBbM1CA==",
       "cpu": [
         "x64"
       ],
@@ -106,9 +106,9 @@
       ]
     },
     "node_modules/@ampcode/cli-win32-x64": {
-      "version": "0.0.1779624958-g6d0650",
-      "resolved": "https://registry.npmjs.org/@ampcode/cli-win32-x64/-/cli-win32-x64-0.0.1779624958-g6d0650.tgz",
-      "integrity": "sha512-PXHOSMf1eairHiDWGXG48W3902H8qdj1VwOyNX/UYmIoQOpTpHzPINa1BJpg6Q+S7Enm4qeevVbW6Hx81CEH3A==",
+      "version": "0.0.1779896748-g596c49",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-win32-x64/-/cli-win32-x64-0.0.1779896748-g596c49.tgz",
+      "integrity": "sha512-OB76DHMOL2Kc1d2EaOPdNWOhHLbySF8hZ5QPvBECjUIBhFwq5VYyav6l26aBlc19Uiag2uTg8S7F12rHH/UEXw==",
       "cpu": [
         "x64"
       ],
@@ -119,11 +119,12 @@
       ]
     },
     "node_modules/@ampcode/sdk": {
-      "version": "0.1.0-20260524123501-g6d0650a",
-      "resolved": "https://registry.npmjs.org/@ampcode/sdk/-/sdk-0.1.0-20260524123501-g6d0650a.tgz",
-      "integrity": "sha512-7qwGTuiXdc5uk5MDLapnZCSE6p4Wk64016I/vi8g5PhDjBFsjlG6uHqNCaN/a8dBaYRsvWJtJNFsXIh/zHz+nQ==",
+      "version": "0.1.0-20260528044221-ge0e19fa",
+      "resolved": "https://registry.npmjs.org/@ampcode/sdk/-/sdk-0.1.0-20260528044221-ge0e19fa.tgz",
+      "integrity": "sha512-yRlzNLfhB1esLNU2+tOToJU47JX/sJ1pnPp5I6jmckgDvVa8qAif2+Tzk07fq7fzHoALkTRsit50Psp/ADBrng==",
       "license": "Amp Commercial License",
       "dependencies": {
+        "@ampcode/cli": "0.0.1779896748-g596c49",
         "zod": "^3.23.8"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amp-acp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amp-acp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.4.8",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.4.8",
-    "@ampcode/cli": "^0.0.1779624958-g6d0650",
-    "@ampcode/sdk": "0.1.0-20260524123501-g6d0650a"
+    "@ampcode/cli": "^0.0.1779896748-g596c49",
+    "@ampcode/sdk": "0.1.0-20260528044221-ge0e19fa"
   },
   "devDependencies": {
     "@types/bun": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-acp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "dist/index.js",

--- a/registry/agent.json
+++ b/registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "amp",
   "name": "Amp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Amp - the frontier coding agent",
   "repository": "https://github.com/tao12345666333/amp-acp",
   "authors": ["tao12345666333"],
@@ -10,23 +10,23 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-darwin-aarch64.tar.gz",
+        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-darwin-aarch64.tar.gz",
         "cmd": "./amp-acp"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-darwin-x86_64.tar.gz",
+        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-darwin-x86_64.tar.gz",
         "cmd": "./amp-acp"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-linux-aarch64.tar.gz",
+        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-linux-aarch64.tar.gz",
         "cmd": "./amp-acp"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-linux-x86_64.tar.gz",
+        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-linux-x86_64.tar.gz",
         "cmd": "./amp-acp"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-windows-x86_64.zip",
+        "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.0/amp-acp-windows-x86_64.zip",
         "cmd": "amp-acp.exe"
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,18 +9,91 @@ import path from 'node:path';
 import os from 'node:os';
 import readline from 'node:readline';
 import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
 import { runAcp } from './run-acp.js';
 
-// Workaround for @ampcode/sdk: its findAmpCommand() resolves @ampcode/cli's
-// pkg.bin.amp ("bin/amp.exe") and then spawns it via `node <path>`. But the
-// new @ampcode/cli package replaces that stub with a native executable during
-// postinstall, so `node bin/amp.exe` blows up with ERR_UNKNOWN_FILE_EXTENSION.
-// Resolving the binary here and exposing it via AMP_CLI_PATH makes the SDK's
-// resolveCliFromEnvironment win (and it spawns non-.js paths directly).
+const AMP_CLI_NATIVE_PACKAGES: Partial<Record<NodeJS.Platform, Partial<Record<string, { pkg: string; bin: string }>>>> = {
+  darwin: {
+    arm64: { pkg: '@ampcode/cli-darwin-arm64', bin: 'amp' },
+    x64: { pkg: '@ampcode/cli-darwin-x64', bin: 'amp' },
+  },
+  linux: {
+    arm64: { pkg: '@ampcode/cli-linux-arm64', bin: 'amp' },
+    x64: { pkg: '@ampcode/cli-linux-x64', bin: 'amp' },
+  },
+  win32: {
+    x64: { pkg: '@ampcode/cli-win32-x64', bin: 'amp.exe' },
+  },
+};
+
+function getPlatformArch(): string {
+  let arch = os.arch();
+  if (process.platform === 'darwin' && arch === 'x64') {
+    const result = spawnSync('sysctl', ['-n', 'sysctl.proc_translated'], { encoding: 'utf8' });
+    if (result.stdout?.trim() === '1') {
+      arch = 'arm64';
+    }
+  }
+  return arch;
+}
+
+function resolveNativeAmpCliBinary(req: ReturnType<typeof createRequire>): string | undefined {
+  const nativePackage = AMP_CLI_NATIVE_PACKAGES[process.platform]?.[getPlatformArch()];
+  if (!nativePackage) return undefined;
+
+  const pkgJsonPath = req.resolve(`${nativePackage.pkg}/package.json`);
+  const binPath = path.join(path.dirname(pkgJsonPath), nativePackage.bin);
+  return fs.existsSync(binPath) ? binPath : undefined;
+}
+
+function isBrokenAmpCliStub(binPath: string): boolean {
+  try {
+    const stat = fs.statSync(binPath);
+    if (stat.size >= 4096) return false;
+    const contents = fs.readFileSync(binPath, 'utf8');
+    return contents.includes('Amp native binary not installed') || contents.startsWith('echo ');
+  } catch {
+    return false;
+  }
+}
+
+function repairAmpCliPackageBin(req: ReturnType<typeof createRequire>): string | undefined {
+  const nativeBinPath = resolveNativeAmpCliBinary(req);
+  if (!nativeBinPath) return undefined;
+
+  const pkgJsonPath = req.resolve('@ampcode/cli/package.json');
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')) as { bin?: { amp?: string } };
+  if (!pkgJson.bin?.amp) return nativeBinPath;
+
+  const binPath = path.resolve(path.dirname(pkgJsonPath), pkgJson.bin.amp);
+  if (!fs.existsSync(binPath) || isBrokenAmpCliStub(binPath)) {
+    fs.copyFileSync(nativeBinPath, binPath);
+    if (process.platform !== 'win32') {
+      fs.chmodSync(binPath, 0o755);
+    }
+  }
+  return binPath;
+}
+
+// Workaround for @ampcode/sdk / @ampcode/cli package resolution differences.
+// The SDK resolves @ampcode/cli's pkg.bin.amp ("bin/amp.exe") before checking
+// AMP_CLI_PATH. With Bun installs, @ampcode/cli's postinstall can be blocked,
+// leaving bin/amp.exe as a tiny non-shebang placeholder shell stub. Spawning that
+// path directly fails with ENOEXEC. Prefer the per-platform optional native
+// package and, when needed, copy it over the placeholder so the SDK's local
+// package resolver also sees a runnable binary.
 function preferBundledAmpCliBinary(): void {
   if (process.env.AMP_CLI_PATH) return;
   try {
     const req = createRequire(import.meta.url);
+    try {
+      const ampCliBin = repairAmpCliPackageBin(req);
+      if (ampCliBin) {
+        process.env.AMP_CLI_PATH = ampCliBin;
+        return;
+      }
+    } catch { /* fall back to package bin / PATH resolution */ }
+
     for (const pkg of ['@ampcode/cli', '@sourcegraph/amp']) {
       try {
         const pkgJsonPath = req.resolve(`${pkg}/package.json`);
@@ -28,6 +101,7 @@ function preferBundledAmpCliBinary(): void {
         if (!pkgJson.bin?.amp) continue;
         const binPath = path.resolve(path.dirname(pkgJsonPath), pkgJson.bin.amp);
         if (!fs.existsSync(binPath)) continue;
+        if (pkg === '@ampcode/cli' && isBrokenAmpCliStub(binPath)) continue;
         if (binPath.endsWith('.js') || binPath.endsWith('.mjs') || binPath.endsWith('.cjs')) continue;
         process.env.AMP_CLI_PATH = binPath;
         return;


### PR DESCRIPTION
## Summary
- bump package version to 0.8.0
- update Zed extension and registry metadata to point at v0.8.0 release artifacts

## Validation
- bun run lint
- bun test src/
- bun run build