### PR TITLE
ci: use frozen lockfile for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint
         run: bun run lint


### PR DESCRIPTION
## Summary
- install dependencies in CI with \bun install v1.3.14 (0d9b296a)

Checked 10 installs across 15 packages (no changes) [7.00ms]
- keep existing lint, unit test, and binary integration test checks

## Local verification
- \
- \bun test v1.3.14 (0d9b296a)
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
[acp] amp-acp v0.8.0 initialized
- \Bundled 21 modules in 6ms

  ./index.js  0.33 MB  (entry point)

   [6ms]  bundle  1 modules
  [63ms] compile  dist/amp-acp-test
bun test v1.3.14 (0d9b296a)