### PR TITLE
Add Amp SDK effort config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Requires Node.js 18+.
 - **Streaming responses** — Amp messages, tool calls, and thinking are streamed in real-time via ACP
 - **Image support** — Handles image content blocks from Amp (base64 and URL)
 - **MCP passthrough** — MCP servers configured in Zed are automatically passed through to Amp
-- **Session modes** — Switch between *Default* (uses Amp's configured behavior — since [Amp Neo](https://ampcode.com/news/neo) this means no prompts unless you've opted into the built-in permissions plugin via `amp.permissions`, `amp.dangerouslyAllowAll: false`, or `amp.guardedFiles.allowlist`) and *Bypass* (force-allow every tool call, overriding any configured permissions plugin)
+- **Session configuration** — Configure permissions (*Default* or *Bypass*), Amp mode (`smart`, `deep`, or `rush`), and reasoning effort (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`) via ACP config options
 - **`/init` command** — Type `/init` to generate an `AGENTS.md` file for your project
 - **Conversation continuity** — Thread context is preserved across multiple prompts within a session
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Requires Node.js 18+.
 - **Streaming responses** — Amp messages, tool calls, and thinking are streamed in real-time via ACP
 - **Image support** — Handles image content blocks from Amp (base64 and URL)
 - **MCP passthrough** — MCP servers configured in Zed are automatically passed through to Amp
-- **Session configuration** — Configure permissions (*Default* or *Bypass*), Amp mode (`smart`, `deep`, or `rush`), and reasoning effort for `smart`/`deep` (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`) via ACP config options
+- **Session configuration** — Configure permissions (*Default* or *Bypass*), Amp mode (`smart`, `deep`, or `rush`), and mode-specific reasoning effort (`smart`: `high`/`xhigh`/`max`, `deep`: `low`/`medium`/`xhigh`) via ACP config options
 - **`/init` command** — Type `/init` to generate an `AGENTS.md` file for your project
 - **Conversation continuity** — Thread context is preserved across multiple prompts within a session
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Requires Node.js 18+.
 - **Streaming responses** — Amp messages, tool calls, and thinking are streamed in real-time via ACP
 - **Image support** — Handles image content blocks from Amp (base64 and URL)
 - **MCP passthrough** — MCP servers configured in Zed are automatically passed through to Amp
-- **Session configuration** — Configure permissions (*Default* or *Bypass*), Amp mode (`smart`, `deep`, or `rush`), and reasoning effort (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`) via ACP config options
+- **Session configuration** — Configure permissions (*Default* or *Bypass*), Amp mode (`smart`, `deep`, or `rush`), and reasoning effort for `smart`/`deep` (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`) via ACP config options
 - **`/init` command** — Type `/init` to generate an `AGENTS.md` file for your project
 - **Conversation continuity** — Thread context is preserved across multiple prompts within a session
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,18 +5,18 @@
     "": {
       "name": "amp-acp",
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.4.8",
+        "@agentclientprotocol/sdk": "0.22.1",
         "@ampcode/cli": "^0.0.1779896748-g596c49",
         "@ampcode/sdk": "0.1.0-20260528044221-ge0e19fa",
       },
       "devDependencies": {
         "@types/bun": "^1.2.5",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.4.8", "", { "dependencies": { "zod": "^3.0.0" } }, "sha512-2hN2CMMWtYVHrUeuapwLu66S2wwOPhq+bLqAryl1cQjKjL5Mzkfq+oxFYFvGdPvBoKpJSxM2pIIQiUH8tGZ3rg=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.22.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ=="],
 
     "@ampcode/cli": ["@ampcode/cli@0.0.1779896748-g596c49", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1779896748-g596c49", "@ampcode/cli-darwin-x64": "0.0.1779896748-g596c49", "@ampcode/cli-linux-arm64": "0.0.1779896748-g596c49", "@ampcode/cli-linux-x64": "0.0.1779896748-g596c49", "@ampcode/cli-win32-x64": "0.0.1779896748-g596c49" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-kXCUoVEBmBl7EXztEPvZJxYubQj57oKGqY34kKQsbXYAl0sCbSSGmwBCSLI08gdK3yJClFgsZyz5VInjvbIKLg=="],
 
@@ -38,7 +38,7 @@
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "amp-acp",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.22.1",
-        "@ampcode/cli": "^0.0.1779896748-g596c49",
-        "@ampcode/sdk": "0.1.0-20260528044221-ge0e19fa",
+        "@ampcode/cli": "0.0.1780291930-gf6d536",
+        "@ampcode/sdk": "0.1.0-20260601042628-gf6d5362",
       },
       "devDependencies": {
         "@types/bun": "^1.2.5",
@@ -18,19 +18,19 @@
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.22.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ=="],
 
-    "@ampcode/cli": ["@ampcode/cli@0.0.1779896748-g596c49", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1779896748-g596c49", "@ampcode/cli-darwin-x64": "0.0.1779896748-g596c49", "@ampcode/cli-linux-arm64": "0.0.1779896748-g596c49", "@ampcode/cli-linux-x64": "0.0.1779896748-g596c49", "@ampcode/cli-win32-x64": "0.0.1779896748-g596c49" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-kXCUoVEBmBl7EXztEPvZJxYubQj57oKGqY34kKQsbXYAl0sCbSSGmwBCSLI08gdK3yJClFgsZyz5VInjvbIKLg=="],
+    "@ampcode/cli": ["@ampcode/cli@0.0.1780291930-gf6d536", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1780291930-gf6d536", "@ampcode/cli-darwin-x64": "0.0.1780291930-gf6d536", "@ampcode/cli-linux-arm64": "0.0.1780291930-gf6d536", "@ampcode/cli-linux-x64": "0.0.1780291930-gf6d536", "@ampcode/cli-win32-x64": "0.0.1780291930-gf6d536" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-9zgUrkMyLnr7nnhslMwpow6EwFBM2mbHz1yH5pJDAl1wi30E0zdrDcBxoXXXGrRdBVHZv4IqGl00qxiwBraKSw=="],
 
-    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1779896748-g596c49", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yl9oasAceWZeZB9WMt6nbbAkX/DiiLhM9OxkF6LiUkxTsyW/vUbecgAQsc+liPsXsd9tvbEx0D/J0A9mQsUIgQ=="],
+    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1780291930-gf6d536", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GkO+6x+sSRKbuW+TwKpHvDHv3fz0pjwSRZyul1j5I/IMhshTrOpJAr07iC8OP6KspS9tDUz5GiWKZOfnOQ1hrQ=="],
 
-    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1779896748-g596c49", "", { "os": "darwin", "cpu": "x64" }, "sha512-U35NdQXxY1HApqbnmbyoykjjcIlylE/eOe/ZdCTIAe3SdWByHxFHYy6+EzrprwpuSXk6YWJ6cLXu9DEro11XgA=="],
+    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1780291930-gf6d536", "", { "os": "darwin", "cpu": "x64" }, "sha512-UfL3vdnhTeLMm5SdPVb3hi3KSof8M+7oUSw8D56xRFs32m6bIE0xZY/KIlbu0z6RYBXC3iGZ5mBo+QiAYlj+qQ=="],
 
-    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1779896748-g596c49", "", { "os": "linux", "cpu": "arm64" }, "sha512-UA26xFK6qyxgNn3VWaGxCGgKEN5gKcUHhEZwC6lbSz6soY/KVlWeJAmcRKfIcl6+393x7kR8S0OjBxQtyCBYHw=="],
+    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1780291930-gf6d536", "", { "os": "linux", "cpu": "arm64" }, "sha512-hjGLtFvDmXmlnRbs4L4f0dZKKrGDzMinRlQzXlW6sz/6SUmVquOOw77U8cqYzV3B2AVsPL7BmLdVBrU4ZEyr9g=="],
 
-    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1779896748-g596c49", "", { "os": "linux", "cpu": "x64" }, "sha512-qbEBgXBsqQ2njNIFtFgvUEnw1EsgBgYZVNBlOUrkV8o4X//9jvPVRD5yI2oqVLXb2IG9q6fhEcu3N54nBbM1CA=="],
+    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1780291930-gf6d536", "", { "os": "linux", "cpu": "x64" }, "sha512-L9Y8ziLgAM8yitq8pDzpfh1uUUdcTKCabv1we0uGr5N8pxthsDwUbDm/E2M7/3WRqm+DKi92ILjaD1tR8iXF8Q=="],
 
-    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1779896748-g596c49", "", { "os": "win32", "cpu": "x64" }, "sha512-OB76DHMOL2Kc1d2EaOPdNWOhHLbySF8hZ5QPvBECjUIBhFwq5VYyav6l26aBlc19Uiag2uTg8S7F12rHH/UEXw=="],
+    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1780291930-gf6d536", "", { "os": "win32", "cpu": "x64" }, "sha512-PQfqI8+GDjkiBUZFmbOirdL+9YFu42XrCxsVBVMefbqqhGcqUe+3XrQ8gkgLDyP/NHSTK9KX8ItN3TPbnHXEbg=="],
 
-    "@ampcode/sdk": ["@ampcode/sdk@0.1.0-20260528044221-ge0e19fa", "", { "dependencies": { "@ampcode/cli": "0.0.1779896748-g596c49", "zod": "^3.23.8" }, "bin": { "amp-sdk": "bin/amp-sdk.js" } }, "sha512-yRlzNLfhB1esLNU2+tOToJU47JX/sJ1pnPp5I6jmckgDvVa8qAif2+Tzk07fq7fzHoALkTRsit50Psp/ADBrng=="],
+    "@ampcode/sdk": ["@ampcode/sdk@0.1.0-20260601042628-gf6d5362", "", { "dependencies": { "@ampcode/cli": "latest", "zod": "^3.23.8" }, "bin": { "amp-sdk": "bin/amp-sdk.js" } }, "sha512-yG/v2upfeNVjHZ6IGhOfuUo8pjv7PJhnNdASQ28SBQUm+nXT/TwWHibddL3T6F4j5A/dsZ4/01MtF5as/IWRYA=="],
 
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
@@ -43,5 +43,17 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@ampcode/sdk/@ampcode/cli": ["@ampcode/cli@0.0.1780306933-g944f6c", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1780306933-g944f6c", "@ampcode/cli-darwin-x64": "0.0.1780306933-g944f6c", "@ampcode/cli-linux-arm64": "0.0.1780306933-g944f6c", "@ampcode/cli-linux-x64": "0.0.1780306933-g944f6c", "@ampcode/cli-win32-x64": "0.0.1780306933-g944f6c" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-JC88ZFDohobtCsxbk0DprBPGxCs7yLAsDiTwDpfZM51eRItJGMPV8fgMfGa84pBMEHDbiJqx+V2dmQKQC2pffQ=="],
+
+    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1780306933-g944f6c", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OznOLHbZ1pyuHrZX4Cxgd22bXbeTmJ/6S8YelJXn6VA5YtsgqMy2LHwDxC9mD1nVfZRryKEXn7SeI9P9mLdpEw=="],
+
+    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1780306933-g944f6c", "", { "os": "darwin", "cpu": "x64" }, "sha512-htmGTt/ZEFg4HGEIASz+owTGBBAc1vN7HM8kr0Vf+jAJRNCeQOkSyI6Wd3n8PQ5n8KRNCE4Cwm9nkQ5wyI/Dqg=="],
+
+    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1780306933-g944f6c", "", { "os": "linux", "cpu": "arm64" }, "sha512-v3v45ajVbiRf/oc41Fj5/tUK/HDREW86AHurpYAAeIOFXYHCnF9NKwirOOyytmCXuWTWqraD9P62WKZTn+XJhA=="],
+
+    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1780306933-g944f6c", "", { "os": "linux", "cpu": "x64" }, "sha512-DoYgDM0JrgJaLTeqdBhGvOC0XnNBKQ9OAb+lUkKBsJ3vRx06rsgCtjUaSwvAB0Na3w5A/PsibqmTdlxA3SoRLw=="],
+
+    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1780306933-g944f6c", "", { "os": "win32", "cpu": "x64" }, "sha512-tm7PEDH3KZNl8CyUx1PU6QVb5xGW1zx0F6HN6ms6bnxyjikcQ7VMgkVLC7OX1uD/rd55XnVE5z/k0RJfBG6Seg=="],
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.2.5",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@types/bun": "^1.2.5",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.22.1",
-    "@ampcode/cli": "^0.0.1779896748-g596c49",
-    "@ampcode/sdk": "0.1.0-20260528044221-ge0e19fa"
+    "@ampcode/cli": "0.0.1780291930-gf6d536",
+    "@ampcode/sdk": "0.1.0-20260601042628-gf6d5362"
   },
   "devDependencies": {
     "@types/bun": "^1.2.5",

--- a/src/acp-protocol.test.ts
+++ b/src/acp-protocol.test.ts
@@ -62,12 +62,29 @@ describe('ACP Protocol End-to-End', () => {
 
     expect(response.sessionId).toBeDefined();
     expect(response.sessionId).toMatch(/^S-/);
-    expect(response.models?.currentModelId).toBe('smart');
-    expect(response.models?.availableModels).toHaveLength(3);
-    expect(response.models?.availableModels?.map((m) => m.modelId)).toEqual(['smart', 'deep', 'rush']);
-    expect(response.modes?.currentModeId).toBe('default');
-    expect(response.modes?.availableModes).toHaveLength(2);
-    expect(response.modes?.availableModes?.map((m) => m.id)).toEqual(['default', 'bypass']);
+    expect(response.models).toBeUndefined();
+    expect(response.modes).toBeUndefined();
+    expect(response.configOptions).toHaveLength(3);
+    expect(response.configOptions?.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
+    expect(response.configOptions?.map((option) => option.category)).toEqual(['mode', 'model', 'thought_level']);
+  });
+
+  it('should handle setSessionConfigOption', async () => {
+    const session = await agentConnection.newSession({
+      cwd: '/tmp',
+      mcpServers: [],
+    });
+
+    const result = await agentConnection.setSessionConfigOption({
+      sessionId: session.sessionId,
+      configId: 'effort',
+      value: 'xhigh',
+    });
+
+    expect(result.configOptions).toHaveLength(3);
+    expect(result.configOptions.find((option) => option.id === 'effort')).toMatchObject({
+      currentValue: 'xhigh',
+    });
   });
 
   it('should handle newSession with MCP servers', async () => {

--- a/src/acp-protocol.test.ts
+++ b/src/acp-protocol.test.ts
@@ -67,6 +67,14 @@ describe('ACP Protocol End-to-End', () => {
     expect(response.configOptions).toHaveLength(3);
     expect(response.configOptions?.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
     expect(response.configOptions?.map((option) => option.category)).toEqual(['mode', 'model', 'thought_level']);
+    expect(response.configOptions?.find((option) => option.id === 'effort')).toMatchObject({
+      currentValue: 'high',
+      options: [
+        { value: 'high', name: 'high' },
+        { value: 'xhigh', name: 'xhigh' },
+        { value: 'max', name: 'max' },
+      ],
+    });
   });
 
   it('should handle setSessionConfigOption', async () => {
@@ -106,6 +114,41 @@ describe('ACP Protocol End-to-End', () => {
       value: 'smart',
     });
     expect(smart.configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
+  });
+
+  it('should scope effort options by Amp mode', async () => {
+    const session = await agentConnection.newSession({
+      cwd: '/tmp',
+      mcpServers: [],
+    });
+
+    const deep = await agentConnection.setSessionConfigOption({
+      sessionId: session.sessionId,
+      configId: 'amp-mode',
+      value: 'deep',
+    });
+    expect(deep.configOptions.find((option) => option.id === 'effort')).toMatchObject({
+      currentValue: 'medium',
+      options: [
+        { value: 'low', name: 'low' },
+        { value: 'medium', name: 'medium' },
+        { value: 'xhigh', name: 'xhigh' },
+      ],
+    });
+
+    const smart = await agentConnection.setSessionConfigOption({
+      sessionId: session.sessionId,
+      configId: 'amp-mode',
+      value: 'smart',
+    });
+    expect(smart.configOptions.find((option) => option.id === 'effort')).toMatchObject({
+      currentValue: 'high',
+      options: [
+        { value: 'high', name: 'high' },
+        { value: 'xhigh', name: 'xhigh' },
+        { value: 'max', name: 'max' },
+      ],
+    });
   });
 
   it('should handle newSession with MCP servers', async () => {

--- a/src/acp-protocol.test.ts
+++ b/src/acp-protocol.test.ts
@@ -87,6 +87,27 @@ describe('ACP Protocol End-to-End', () => {
     });
   });
 
+  it('should hide effort config when Amp mode is rush', async () => {
+    const session = await agentConnection.newSession({
+      cwd: '/tmp',
+      mcpServers: [],
+    });
+
+    const rush = await agentConnection.setSessionConfigOption({
+      sessionId: session.sessionId,
+      configId: 'amp-mode',
+      value: 'rush',
+    });
+    expect(rush.configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode']);
+
+    const smart = await agentConnection.setSessionConfigOption({
+      sessionId: session.sessionId,
+      configId: 'amp-mode',
+      value: 'smart',
+    });
+    expect(smart.configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
+  });
+
   it('should handle newSession with MCP servers', async () => {
     const response = await agentConnection.newSession({
       cwd: '/tmp/test',

--- a/src/mcp-config.test.ts
+++ b/src/mcp-config.test.ts
@@ -171,6 +171,19 @@ describe('MCP Configuration Passthrough', () => {
   });
 
   describe('Edge cases', () => {
+    it('should ignore ACP transport MCP servers', () => {
+      const acpMcpServers: McpServer[] = [
+        {
+          type: 'acp',
+          id: 'mcp-1',
+          name: 'embedded',
+        },
+      ];
+
+      const result = convertAcpMcpServersToAmpConfig(acpMcpServers);
+      expect(result).toEqual({});
+    });
+
     it('should handle empty mcpServers array', () => {
       const result = convertAcpMcpServersToAmpConfig([]);
       expect(result).toEqual({});

--- a/src/mcp-config.ts
+++ b/src/mcp-config.ts
@@ -1,14 +1,7 @@
 import type { McpServer } from '@agentclientprotocol/sdk';
+import type { AmpOptions } from '@ampcode/sdk';
 
-interface AmpMcpServerConfig {
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
-}
-
-export type AmpMcpConfig = Record<string, AmpMcpServerConfig>;
+export type AmpMcpConfig = Exclude<AmpOptions['mcpConfig'], string | undefined>;
 
 export function convertAcpMcpServersToAmpConfig(mcpServers: McpServer[] | undefined | null): AmpMcpConfig {
   const mcpConfig: AmpMcpConfig = {};

--- a/src/mcp-config.ts
+++ b/src/mcp-config.ts
@@ -17,25 +17,30 @@ export function convertAcpMcpServersToAmpConfig(mcpServers: McpServer[] | undefi
   }
 
   for (const server of mcpServers) {
-    if ('type' in server && (server.type === 'http' || server.type === 'sse')) {
+    if ('type' in server) {
+      if (server.type === 'acp') {
+        continue;
+      }
+
       const headers: Record<string, string> = {};
-      for (const h of server.headers) {
-        headers[h.name] = h.value;
+      for (const header of server.headers) {
+        headers[header.name] = header.value;
       }
       mcpConfig[server.name] = {
         url: server.url,
         headers: Object.keys(headers).length > 0 ? headers : undefined,
       };
-    } else {
-      const env = server.env.length > 0
-        ? Object.fromEntries(server.env.map((e) => [e.name, e.value]))
-        : undefined;
-      mcpConfig[server.name] = {
-        command: server.command,
-        args: server.args,
-        env,
-      };
+      continue;
     }
+
+    const env = server.env.length > 0
+      ? Object.fromEntries(server.env.map((entry) => [entry.name, entry.value]))
+      : undefined;
+    mcpConfig[server.name] = {
+      command: server.command,
+      args: server.args,
+      env,
+    };
   }
 
   return mcpConfig;

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -58,7 +58,7 @@ describe('AmpAcpAgent prompt() continue option', () => {
 
   it('passes selected Amp model as SDK mode', async () => {
     const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    await agent.setSessionModel({ sessionId: session.sessionId, modelId: 'deep' });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'deep' });
     await agent.prompt({
       sessionId: session.sessionId,
       prompt: [{ type: 'text', text: 'hello' }],
@@ -66,6 +66,31 @@ describe('AmpAcpAgent prompt() continue option', () => {
 
     expect(capturedCalls).toHaveLength(1);
     expect(capturedCalls[0]!.options.mode).toBe('deep');
+  });
+
+  it('passes selected Amp reasoning effort to the SDK', async () => {
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'effort', value: 'xhigh' });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]!.options.mode).toBe('smart');
+    expect(capturedCalls[0]!.options.effort).toBe('xhigh');
+  });
+
+  it('passes selected permission config to the SDK', async () => {
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'permission', value: 'bypass' });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]!.options.dangerouslyAllowAll).toBe(true);
   });
 
   it('sets continue=true on first prompt when AMP_ACP_CONTINUE_LATEST is set', async () => {

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -66,6 +66,7 @@ describe('AmpAcpAgent prompt() continue option', () => {
 
     expect(capturedCalls).toHaveLength(1);
     expect(capturedCalls[0]!.options.mode).toBe('deep');
+    expect(capturedCalls[0]!.options.effort).toBe('medium');
   });
 
   it('passes selected Amp reasoning effort to the SDK', async () => {
@@ -79,6 +80,20 @@ describe('AmpAcpAgent prompt() continue option', () => {
     expect(capturedCalls).toHaveLength(1);
     expect(capturedCalls[0]!.options.mode).toBe('smart');
     expect(capturedCalls[0]!.options.effort).toBe('xhigh');
+  });
+
+  it('passes selected deep reasoning effort to the SDK', async () => {
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'deep' });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'effort', value: 'low' });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]!.options.mode).toBe('deep');
+    expect(capturedCalls[0]!.options.effort).toBe('low');
   });
 
   it('does not pass reasoning effort for rush mode', async () => {

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -81,6 +81,20 @@ describe('AmpAcpAgent prompt() continue option', () => {
     expect(capturedCalls[0]!.options.effort).toBe('xhigh');
   });
 
+  it('does not pass reasoning effort for rush mode', async () => {
+    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'effort', value: 'xhigh' });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'rush' });
+    await agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]!.options.mode).toBe('rush');
+    expect(capturedCalls[0]!.options.effort).toBeUndefined();
+  });
+
   it('passes selected permission config to the SDK', async () => {
     const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
     await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'permission', value: 'bypass' });

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,8 +71,12 @@ function isAmpEffort(effort: string): effort is AmpEffort {
   return AMP_EFFORT_LEVELS.some((level) => level === effort);
 }
 
+function supportsReasoningEffort(model: AmpModelId): boolean {
+  return model === 'smart' || model === 'deep';
+}
+
 function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'effort'>): SessionConfigOption[] {
-  return [
+  const options: SessionConfigOption[] = [
     {
       type: 'select',
       id: CONFIG_PERMISSION,
@@ -107,7 +111,10 @@ function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'eff
         description: model.description,
       })),
     },
-    {
+  ];
+
+  if (supportsReasoningEffort(s.model)) {
+    options.push({
       type: 'select',
       id: CONFIG_EFFORT,
       name: 'Effort',
@@ -118,8 +125,10 @@ function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'eff
         value: effort,
         name: effort,
       })),
-    },
-  ];
+    });
+  }
+
+  return options;
 }
 
 interface SessionState {
@@ -278,7 +287,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
       mode: s.model,
     };
 
-    if (s.model === 'smart' || s.model === 'deep') {
+    if (supportsReasoningEffort(s.model)) {
       options.effort = s.effort;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,8 @@ import {
   type AuthenticateRequest,
   type AuthenticateResponse,
   type CancelNotification,
+  type SetSessionConfigOptionRequest,
+  type SetSessionConfigOptionResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
   type SetSessionModelRequest,
@@ -20,14 +22,20 @@ import {
   type WriteTextFileRequest,
   type WriteTextFileResponse,
   type ClientCapabilities,
+  type SessionConfigOption,
 } from '@agentclientprotocol/sdk';
-import { execute, type StreamMessage } from '@ampcode/sdk';
+import { execute, type AmpOptions, type StreamMessage } from '@ampcode/sdk';
 import { convertAcpMcpServersToAmpConfig, type AmpMcpConfig } from './mcp-config.js';
 import { toAcpNotifications } from './to-acp.js';
 import path from 'node:path';
 import packageJson from '../package.json';
 
 const PACKAGE_VERSION: string = packageJson.version;
+const CONFIG_PERMISSION = 'permission';
+const CONFIG_AMP_MODE = 'amp-mode';
+const CONFIG_EFFORT = 'effort';
+const PERMISSION_MODES = ['default', 'bypass'] as const;
+const AMP_EFFORT_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 
 const AMP_MODELS = [
   {
@@ -48,9 +56,70 @@ const AMP_MODELS = [
 ] as const;
 
 type AmpModelId = typeof AMP_MODELS[number]['modelId'];
+type PermissionMode = typeof PERMISSION_MODES[number];
+type AmpEffort = typeof AMP_EFFORT_LEVELS[number];
 
 function isAmpModelId(modelId: string): modelId is AmpModelId {
   return AMP_MODELS.some((model) => model.modelId === modelId);
+}
+
+function isPermissionMode(mode: string): mode is PermissionMode {
+  return PERMISSION_MODES.some((permissionMode) => permissionMode === mode);
+}
+
+function isAmpEffort(effort: string): effort is AmpEffort {
+  return AMP_EFFORT_LEVELS.some((level) => level === effort);
+}
+
+function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'effort'>): SessionConfigOption[] {
+  return [
+    {
+      type: 'select',
+      id: CONFIG_PERMISSION,
+      name: 'Permissions',
+      description: 'Controls whether Amp uses configured permissions or force-allows tool calls.',
+      category: 'mode',
+      currentValue: s.mode,
+      options: [
+        {
+          value: 'default',
+          name: 'Default',
+          description:
+            "Use Amp's configured behavior. As of Amp Neo, tools run without prompts unless you've opted into permissions.",
+        },
+        {
+          value: 'bypass',
+          name: 'Bypass',
+          description: 'Force-allow every tool call, overriding any configured permissions plugin.',
+        },
+      ],
+    },
+    {
+      type: 'select',
+      id: CONFIG_AMP_MODE,
+      name: 'Amp Mode',
+      description: 'Select the Amp SDK execution mode.',
+      category: 'model',
+      currentValue: s.model,
+      options: AMP_MODELS.map((model) => ({
+        value: model.modelId,
+        name: model.name,
+        description: model.description,
+      })),
+    },
+    {
+      type: 'select',
+      id: CONFIG_EFFORT,
+      name: 'Effort',
+      description: 'Set model reasoning effort for Amp smart and deep modes.',
+      category: 'thought_level',
+      currentValue: s.effort,
+      options: AMP_EFFORT_LEVELS.map((effort) => ({
+        value: effort,
+        name: effort,
+      })),
+    },
+  ];
 }
 
 interface SessionState {
@@ -58,8 +127,9 @@ interface SessionState {
   controller: AbortController | null;
   cancelled: boolean;
   active: boolean;
-  mode: string;
+  mode: PermissionMode;
   model: AmpModelId;
+  effort: AmpEffort;
   mcpConfig: AmpMcpConfig;
   cwd: string;
 }
@@ -117,39 +187,22 @@ export class AmpAcpAgent implements Agent {
 
     const mcpConfig = convertAcpMcpServersToAmpConfig(params.mcpServers);
 
-    this.sessions.set(sessionId, {
+    const session: SessionState = {
       threadId: null,
       controller: null,
       cancelled: false,
       active: false,
       mode: 'default',
       model: 'smart',
+      effort: 'medium',
       mcpConfig,
       cwd: params.cwd || process.cwd(),
-    });
+    };
+    this.sessions.set(sessionId, session);
 
     const result: NewSessionResponse = {
       sessionId,
-      models: {
-        currentModelId: 'smart',
-        availableModels: [...AMP_MODELS],
-      },
-      modes: {
-        currentModeId: 'default',
-        availableModes: [
-          {
-            id: 'default',
-            name: 'Default',
-            description:
-              "Use Amp's configured behavior. As of Amp Neo, tools run without prompts unless you've opted into permissions (e.g. amp.permissions, amp.dangerouslyAllowAll: false, or amp.guardedFiles.allowlist).",
-          },
-          {
-            id: 'bypass',
-            name: 'Bypass',
-            description: 'Force-allow every tool call, overriding any configured permissions plugin (dangerouslyAllowAll).',
-          },
-        ],
-      },
+      configOptions: buildSessionConfigOptions(session),
     };
 
     setImmediate(async () => {
@@ -219,11 +272,15 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
       }
     }
 
-    const options: Record<string, unknown> = {
+    const options: AmpOptions = {
       cwd: s.cwd,
       env: { TERM: 'dumb' },
       mode: s.model,
     };
+
+    if (s.model === 'smart' || s.model === 'deep') {
+      options.effort = s.effort;
+    }
 
     if (s.mode === 'bypass') {
       options.dangerouslyAllowAll = true;
@@ -298,6 +355,39 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
     }
   }
 
+  async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
+    const s = this.sessions.get(params.sessionId);
+    if (!s) throw new Error('Session not found');
+    if (typeof params.value !== 'string') {
+      throw new Error(`Unsupported value for ${params.configId}`);
+    }
+
+    switch (params.configId) {
+      case CONFIG_PERMISSION:
+        if (!isPermissionMode(params.value)) {
+          throw new Error(`Unsupported permission mode: ${params.value}`);
+        }
+        s.mode = params.value;
+        break;
+      case CONFIG_AMP_MODE:
+        if (!isAmpModelId(params.value)) {
+          throw new Error(`Unsupported Amp mode: ${params.value}`);
+        }
+        s.model = params.value;
+        break;
+      case CONFIG_EFFORT:
+        if (!isAmpEffort(params.value)) {
+          throw new Error(`Unsupported effort: ${params.value}`);
+        }
+        s.effort = params.value;
+        break;
+      default:
+        throw new Error(`Unsupported config option: ${params.configId}`);
+    }
+
+    return { configOptions: buildSessionConfigOptions(s) };
+  }
+
   async setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
     const s = this.sessions.get(params.sessionId);
     if (!s) throw new Error('Session not found');
@@ -311,6 +401,9 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
     const s = this.sessions.get(params.sessionId);
     if (!s) throw new Error('Session not found');
+    if (!isPermissionMode(params.modeId)) {
+      throw new Error(`Unsupported mode: ${params.modeId}`);
+    }
     s.mode = params.modeId;
     return {};
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -427,7 +427,20 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
         throw new Error(`Unsupported config option: ${params.configId}`);
     }
 
-    return { configOptions: buildSessionConfigOptions(s) };
+    const configOptions = buildSessionConfigOptions(s);
+    try {
+      await this.client.sessionUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: 'config_option_update',
+          configOptions,
+        },
+      });
+    } catch (e) {
+      console.error('[acp] failed to send config_option_update', e);
+    }
+
+    return { configOptions };
   }
 
   async setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,8 @@ const CONFIG_PERMISSION = 'permission';
 const CONFIG_AMP_MODE = 'amp-mode';
 const CONFIG_EFFORT = 'effort';
 const PERMISSION_MODES = ['default', 'bypass'] as const;
-const AMP_EFFORT_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+const AMP_SMART_EFFORT_LEVELS = ['high', 'xhigh', 'max'] as const;
+const AMP_DEEP_EFFORT_LEVELS = ['low', 'medium', 'xhigh'] as const;
 
 const AMP_MODELS = [
   {
@@ -56,8 +57,16 @@ const AMP_MODELS = [
 ] as const;
 
 type AmpModelId = typeof AMP_MODELS[number]['modelId'];
+type AmpEffortMode = Extract<AmpModelId, 'smart' | 'deep'>;
 type PermissionMode = typeof PERMISSION_MODES[number];
-type AmpEffort = typeof AMP_EFFORT_LEVELS[number];
+type AmpSmartEffort = typeof AMP_SMART_EFFORT_LEVELS[number];
+type AmpDeepEffort = typeof AMP_DEEP_EFFORT_LEVELS[number];
+type AmpEffort = AmpSmartEffort | AmpDeepEffort;
+
+interface SessionEfforts {
+  smart: AmpSmartEffort;
+  deep: AmpDeepEffort;
+}
 
 function isAmpModelId(modelId: string): modelId is AmpModelId {
   return AMP_MODELS.some((model) => model.modelId === modelId);
@@ -67,15 +76,28 @@ function isPermissionMode(mode: string): mode is PermissionMode {
   return PERMISSION_MODES.some((permissionMode) => permissionMode === mode);
 }
 
-function isAmpEffort(effort: string): effort is AmpEffort {
-  return AMP_EFFORT_LEVELS.some((level) => level === effort);
-}
-
-function supportsReasoningEffort(model: AmpModelId): boolean {
+function supportsReasoningEffort(model: AmpModelId): model is AmpEffortMode {
   return model === 'smart' || model === 'deep';
 }
 
-function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'effort'>): SessionConfigOption[] {
+function effortLevelsForModel(model: AmpEffortMode): readonly AmpEffort[] {
+  return model === 'smart' ? AMP_SMART_EFFORT_LEVELS : AMP_DEEP_EFFORT_LEVELS;
+}
+
+function isSmartEffort(effort: string): effort is AmpSmartEffort {
+  return AMP_SMART_EFFORT_LEVELS.some((level) => level === effort);
+}
+
+function isDeepEffort(effort: string): effort is AmpDeepEffort {
+  return AMP_DEEP_EFFORT_LEVELS.some((level) => level === effort);
+}
+
+function currentEffort(s: Pick<SessionState, 'model' | 'efforts'>): AmpEffort | undefined {
+  if (!supportsReasoningEffort(s.model)) return undefined;
+  return s.efforts[s.model];
+}
+
+function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'efforts'>): SessionConfigOption[] {
   const options: SessionConfigOption[] = [
     {
       type: 'select',
@@ -114,14 +136,15 @@ function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'eff
   ];
 
   if (supportsReasoningEffort(s.model)) {
+    const effortLevels = effortLevelsForModel(s.model);
     options.push({
       type: 'select',
       id: CONFIG_EFFORT,
       name: 'Effort',
-      description: 'Set model reasoning effort for Amp smart and deep modes.',
+      description: `Set model reasoning effort for Amp ${s.model} mode.`,
       category: 'thought_level',
-      currentValue: s.effort,
-      options: AMP_EFFORT_LEVELS.map((effort) => ({
+      currentValue: s.efforts[s.model],
+      options: effortLevels.map((effort) => ({
         value: effort,
         name: effort,
       })),
@@ -138,7 +161,7 @@ interface SessionState {
   active: boolean;
   mode: PermissionMode;
   model: AmpModelId;
-  effort: AmpEffort;
+  efforts: SessionEfforts;
   mcpConfig: AmpMcpConfig;
   cwd: string;
 }
@@ -203,7 +226,7 @@ export class AmpAcpAgent implements Agent {
       active: false,
       mode: 'default',
       model: 'smart',
-      effort: 'medium',
+      efforts: { smart: 'high', deep: 'medium' },
       mcpConfig,
       cwd: params.cwd || process.cwd(),
     };
@@ -288,7 +311,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
     };
 
     if (supportsReasoningEffort(s.model)) {
-      options.effort = s.effort;
+      options.effort = currentEffort(s);
     }
 
     if (s.mode === 'bypass') {
@@ -385,10 +408,20 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
         s.model = params.value;
         break;
       case CONFIG_EFFORT:
-        if (!isAmpEffort(params.value)) {
-          throw new Error(`Unsupported effort: ${params.value}`);
+        if (!supportsReasoningEffort(s.model)) {
+          throw new Error(`Effort is not supported for Amp mode: ${s.model}`);
         }
-        s.effort = params.value;
+        if (s.model === 'smart') {
+          if (!isSmartEffort(params.value)) {
+            throw new Error(`Unsupported effort for smart: ${params.value}`);
+          }
+          s.efforts.smart = params.value;
+        } else {
+          if (!isDeepEffort(params.value)) {
+            throw new Error(`Unsupported effort for deep: ${params.value}`);
+          }
+          s.efforts.deep = params.value;
+        }
         break;
       default:
         throw new Error(`Unsupported config option: ${params.configId}`);

--- a/test/binary.test.ts
+++ b/test/binary.test.ts
@@ -120,7 +120,7 @@ describe('Binary integration tests', () => {
     expect(label).toBe('Amp API Key Setup');
   });
 
-  it('session/new returns sessionId and modes', async () => {
+  it('session/new returns sessionId and config options', async () => {
     const resp = await sendAndWait('session/new', {
       cwd: '/tmp/test',
       mcpServers: [],
@@ -130,10 +130,34 @@ describe('Binary integration tests', () => {
     expect(resp.result!.sessionId).toBeDefined();
     expect(typeof resp.result!.sessionId).toBe('string');
     expect((resp.result!.sessionId as string).startsWith('S-')).toBe(true);
-    const modes = resp.result!.modes as Record<string, unknown>;
-    expect(modes.currentModeId).toBe('default');
-    const availableModes = modes.availableModes as Array<{ id: string }>;
-    expect(availableModes.map((m) => m.id)).toEqual(['default', 'bypass']);
+    expect(resp.result!.modes).toBeUndefined();
+    expect(resp.result!.models).toBeUndefined();
+    const configOptions = resp.result!.configOptions as Array<{ id: string; category?: string; currentValue?: string; options?: Array<{ value: string }> }>;
+    expect(configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
+    expect(configOptions.map((option) => option.category)).toEqual(['mode', 'model', 'thought_level']);
+    const effort = configOptions.find((option) => option.id === 'effort')!;
+    expect(effort.currentValue).toBe('high');
+    expect(effort.options?.map((option) => option.value)).toEqual(['high', 'xhigh', 'max']);
+  });
+
+  it('session/set_config_option updates effort options for Amp mode', async () => {
+    const sessionResp = await sendAndWait('session/new', {
+      cwd: '/tmp/test',
+      mcpServers: [],
+    });
+    const sessionId = sessionResp.result!.sessionId as string;
+
+    const resp = await sendAndWait('session/set_config_option', {
+      sessionId,
+      configId: 'amp-mode',
+      value: 'deep',
+    });
+
+    expect(resp.result).toBeDefined();
+    const configOptions = resp.result!.configOptions as Array<{ id: string; currentValue?: string; options?: Array<{ value: string }> }>;
+    const effort = configOptions.find((option) => option.id === 'effort')!;
+    expect(effort.currentValue).toBe('medium');
+    expect(effort.options?.map((option) => option.value)).toEqual(['low', 'medium', 'xhigh']);
   });
 
   it('session/new with MCP servers returns valid sessionId', async () => {


### PR DESCRIPTION
## Summary

This PR upgrades `@ampcode/sdk` and exposes Amp SDK runtime settings through ACP `configOptions` instead of the legacy `modes`/`models` selectors.

Zed prefers `configOptions` when they are present, so the adapter now provides three session configuration selectors:

- **Permissions** (`category: mode`)
  - `default`: use Amp's configured permission behavior
  - `bypass`: set `dangerouslyAllowAll: true`
- **Amp Mode** (`category: model`)
  - `smart`
  - `deep`
  - `rush`
- **Effort** (`category: thought_level`)
  - shown only for Amp modes that support reasoning effort
  - hidden for `rush`

## Effort support matrix

| Amp mode | Effort selector shown? | Supported effort values | SDK options sent |
| --- | --- | --- | --- |
| `smart` | Yes | `high`, `xhigh`, `max` | `{ mode: "smart", effort }` |
| `deep` | Yes | `low`, `medium`, `xhigh` | `{ mode: "deep", effort }` |
| `rush` | No | N/A | `{ mode: "rush" }` |

Defaults:

- `smart` defaults to `high`
- `deep` defaults to `medium`
- `rush` does not send `effort`

The adapter tracks separate effort selections for `smart` and `deep`, so switching modes preserves each mode's last valid effort selection without ever presenting an invalid current value.

## Runtime behavior

- `newSession` returns ACP `configOptions`, so Zed uses the newer config option UI and does not create the legacy mode/model selectors.
- `session/set_config_option` updates session state and returns the full, current config option list.
- When Amp mode changes:
  - switching to `smart` returns effort options `high`, `xhigh`, `max`
  - switching to `deep` returns effort options `low`, `medium`, `xhigh`
  - switching to `rush` omits the effort config entirely
- The adapter also sends a `config_option_update` session notification after config changes so Zed refreshes the selector UI immediately.

## Validation

- `bun run lint`
- `bun test src/`
- `bun run build:binary`
