### PR TITLE
Use Amp CLI as the default execution transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Unit tests
         run: bun run test
 
-      - name: Binary integration tests
+      - name: Binary and ACP client end-to-end tests
         run: bun run test:binary

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Run `amp login` before starting amp-acp. The adapter and CLI share the same Amp 
 - **Streaming responses** — Amp messages, tool calls, and thinking are streamed in real-time via ACP
 - **Image support** — Handles image content blocks from Amp (base64 and URL)
 - **MCP passthrough** — MCP servers configured in Zed are automatically passed through to Amp
-- **Session configuration** — Configure permissions (*Default* or *Bypass*), Amp mode (`smart`, `deep`, or `rush`), and mode-specific reasoning effort (`smart`: `high`/`xhigh`/`max`, `deep`: `low`/`medium`/`xhigh`) via ACP config options
+- **Session configuration** — Configure permissions (*Default* or *Bypass*) and the current Amp mode (`low`, `medium`, `high`, or `ultra`) via ACP config options
 - **`/init` command** — Type `/init` to generate an `AGENTS.md` file for your project
 - **Conversation continuity** — Thread context is preserved across multiple prompts within a session
 
@@ -98,7 +98,7 @@ When the environment variable `AMP_ACP_CONTINUE_LATEST=1` is set, the first prom
 
 ### Amp execution transport
 
-By default, amp-acp executes the bundled Amp CLI directly through its streaming JSON interface. Set `AMP_ACP_TRANSPORT=sdk` to use `@ampcode/sdk` as a compatibility fallback.
+By default, amp-acp executes the installed Amp CLI directly through its streaming JSON interface. Set `AMP_ACP_TRANSPORT=sdk` to use `@ampcode/sdk` as a legacy compatibility fallback; current Amp modes are mapped to the closest legacy SDK mode and effort settings.
 
 ## MCP Configuration Passthrough
 
@@ -174,6 +174,14 @@ bun test src/        # Run unit tests
 bun run test:binary  # Run binary integration and ACP client E2E tests
 bun run test:all     # Run all tests
 ```
+
+The regular suite uses a deterministic fake CLI and is safe for CI. Maintainers can additionally verify the complete path against their installed, authenticated Amp CLI:
+
+```bash
+AMP_ACP_LIVE_E2E=1 AMP_ACP_REAL_CLI_PATH="$(command -v amp)" bun run test:e2e:real
+```
+
+This opt-in test is never enabled by CI. It creates a temporary workspace, runs two short prompts in `low` mode, verifies streaming and same-thread continuation through the official ACP client SDK, and consumes a small amount of Amp usage.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Requires Node.js 18+.
 
 When the environment variable `AMP_ACP_CONTINUE_LATEST=1` is set, the first prompt in a fresh ACP session will continue the most recent Amp thread on this installation (equivalent to `amp threads continue`) instead of starting a new one. Useful when the ACP session follows on from prior `amp` CLI activity (for example, a one-shot `amp -x` invocation) and you want the chat to inherit that context. Off by default.
 
+### Amp execution transport
+
+By default, amp-acp uses `@ampcode/sdk` to execute Amp. Set `AMP_ACP_TRANSPORT=cli` to use the bundled Amp CLI directly with its streaming JSON interface instead. The CLI transport is experimental and is intended for compatibility testing against the SDK transport.
+
 ## MCP Configuration Passthrough
 
 MCP servers configured in Zed's `context_servers` are automatically forwarded to Amp. This is compatible with how other ACP agents like [Claude Code](https://github.com/zed-industries/claude-code-acp) and [Codex](https://github.com/zed-industries/codex-acp) handle MCP servers.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When the environment variable `AMP_ACP_CONTINUE_LATEST=1` is set, the first prom
 
 ### Amp execution transport
 
-By default, amp-acp uses `@ampcode/sdk` to execute Amp. Set `AMP_ACP_TRANSPORT=cli` to use the bundled Amp CLI directly with its streaming JSON interface instead. The CLI transport is experimental and is intended for compatibility testing against the SDK transport.
+By default, amp-acp executes the bundled Amp CLI directly through its streaming JSON interface. Set `AMP_ACP_TRANSPORT=sdk` to use `@ampcode/sdk` as a compatibility fallback.
 
 ## MCP Configuration Passthrough
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@
 
 Use [Amp](https://ampcode.com) from [ACP](https://agentclientprotocol.com/)-compatible clients such as [Zed](https://zed.dev) or [Toad](https://github.com/batrachianai/toad).
 
+## Prerequisites
+
+amp-acp uses the Amp CLI as its default execution runtime. Install the [latest Amp CLI](https://ampcode.com/manual#get-started), sign in, and verify it is available before installing the adapter:
+
+```bash
+amp login
+amp --version
+```
+
+If your editor does not inherit your shell `PATH`, set `AMP_CLI_PATH` to the absolute path printed by `command -v amp` (macOS/Linux) or `where amp` (Windows).
+
 ## Installation
 
 ### Option 1: Zed ACP Registry (Recommended)
@@ -21,7 +32,7 @@ Zed will automatically download the correct binary for your platform.
 
 ### Option 2: Pre-built Binary
 
-Download a standalone binary from the [GitHub Releases](https://github.com/tao12345666333/amp-acp/releases) page — no runtime dependencies required.
+Download the adapter binary from the [GitHub Releases](https://github.com/tao12345666333/amp-acp/releases) page. The adapter itself has no JavaScript runtime dependency, but the Amp CLI described above is required for agent execution.
 
 | Platform | Architecture | Binary |
 |----------|-------------|--------|
@@ -38,7 +49,10 @@ Download the binary for your platform, make it executable (`chmod +x` on Linux/m
   "agent_servers": {
     "Amp": {
       "type": "custom",
-      "command": "/path/to/amp-acp-darwin-arm64"
+      "command": "/path/to/amp-acp-darwin-arm64",
+      "env": {
+        "AMP_CLI_PATH": "/absolute/path/to/amp"
+      }
     }
   }
 }
@@ -54,7 +68,7 @@ Download the binary for your platform, make it executable (`chmod +x` on Linux/m
       "command": "npx",
       "args": ["-y", "amp-acp"],
       "env": {
-        "AMP_API_KEY": "your-api-key-here"
+        "AMP_CLI_PATH": "/absolute/path/to/amp"
       }
     }
   }
@@ -65,9 +79,7 @@ Requires Node.js 18+.
 
 ## Authentication
 
-**If you [have Amp CLI installed](https://ampcode.com/manual#getting-started-command-line-interface)**: Run `amp login` first — credentials are shared automatically.
-
-**If you don't have Amp CLI**: Run `amp-acp --setup` to configure your API key interactively. Alternatively, you can start a chat in Zed's Agent Panel — it will automatically trigger the setup flow if no credentials are found, just follow the prompts.
+Run `amp login` before starting amp-acp. The adapter and CLI share the same Amp credentials. For headless environments, `AMP_API_KEY` is also supported. `amp-acp --setup` remains available as an interactive API-key setup fallback.
 
 ![Auth Process](img/auth-process.png)
 
@@ -159,7 +171,7 @@ bun install
 bun run build        # Bundle to dist/index.js
 bun run lint         # Type-check with tsc
 bun test src/        # Run unit tests
-bun run test:binary  # Run binary integration tests
+bun run test:binary  # Run binary integration and ACP client E2E tests
 bun run test:all     # Run all tests
 ```
 
@@ -169,7 +181,9 @@ bun run test:all     # Run all tests
 
 **Connection issues**: Restart Zed and try again. The adapter creates a fresh connection each time.
 
-**Tool execution problems**: Check Zed's output panel for detailed error messages from the Amp SDK.
+**Amp CLI not found**: Run `amp --version` in a terminal. If it works there but not in your editor, set `AMP_CLI_PATH` to the absolute CLI path in the agent server environment.
+
+**Tool execution problems**: Check Zed's output panel for detailed errors from the Amp CLI.
 
 **MCP server not connecting**: Ensure the MCP server command is correct and any required environment variables are set. Check Zed's logs for connection errors.
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "amp-acp",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.2.1",
-        "@ampcode/cli": "0.0.1780291930-gf6d536",
         "@ampcode/sdk": "0.1.0-20260605144103-g77da114",
       },
       "devDependencies": {
@@ -18,17 +17,17 @@
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
 
-    "@ampcode/cli": ["@ampcode/cli@0.0.1780291930-gf6d536", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1780291930-gf6d536", "@ampcode/cli-darwin-x64": "0.0.1780291930-gf6d536", "@ampcode/cli-linux-arm64": "0.0.1780291930-gf6d536", "@ampcode/cli-linux-x64": "0.0.1780291930-gf6d536", "@ampcode/cli-win32-x64": "0.0.1780291930-gf6d536" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-9zgUrkMyLnr7nnhslMwpow6EwFBM2mbHz1yH5pJDAl1wi30E0zdrDcBxoXXXGrRdBVHZv4IqGl00qxiwBraKSw=="],
+    "@ampcode/cli": ["@ampcode/cli@0.0.1781102632-gaaab69", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1781102632-gaaab69", "@ampcode/cli-darwin-x64": "0.0.1781102632-gaaab69", "@ampcode/cli-linux-arm64": "0.0.1781102632-gaaab69", "@ampcode/cli-linux-x64": "0.0.1781102632-gaaab69", "@ampcode/cli-win32-x64": "0.0.1781102632-gaaab69" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-smAPY+kwkuaindyYY+ft8xja4Nf4AzACZ4a8Y4ShBKapM9Z4aHBbqrG4N+pxJIOhwOY0qigAxwiSoHeXRmBaJw=="],
 
-    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1780291930-gf6d536", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GkO+6x+sSRKbuW+TwKpHvDHv3fz0pjwSRZyul1j5I/IMhshTrOpJAr07iC8OP6KspS9tDUz5GiWKZOfnOQ1hrQ=="],
+    "@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1781102632-gaaab69", "", { "os": "darwin", "cpu": "arm64" }, "sha512-c5wos9ju//rrwTCIkVT7I0kPdnbnDr0kFHJnM0hIPLJIj/BSi5xvje9hdHOW+/korziZGu4KsfISsqUEWAaktw=="],
 
-    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1780291930-gf6d536", "", { "os": "darwin", "cpu": "x64" }, "sha512-UfL3vdnhTeLMm5SdPVb3hi3KSof8M+7oUSw8D56xRFs32m6bIE0xZY/KIlbu0z6RYBXC3iGZ5mBo+QiAYlj+qQ=="],
+    "@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1781102632-gaaab69", "", { "os": "darwin", "cpu": "x64" }, "sha512-dSIhBf4Z/EUZTpmyPBrl91IiQYlfkSgQpPOuwrUE5DSNPhL/6VgKHAIBUJkLsPKgC39EFFLUP5s6mGO1WtfOmg=="],
 
-    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1780291930-gf6d536", "", { "os": "linux", "cpu": "arm64" }, "sha512-hjGLtFvDmXmlnRbs4L4f0dZKKrGDzMinRlQzXlW6sz/6SUmVquOOw77U8cqYzV3B2AVsPL7BmLdVBrU4ZEyr9g=="],
+    "@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1781102632-gaaab69", "", { "os": "linux", "cpu": "arm64" }, "sha512-QbsTwan90RWWr2JOdS2HbCQ835dWbFKic+uzktAgcfiWuxCvKB93SMPX27heLbjkoMnYAcLfzalv9OU9A6rcPQ=="],
 
-    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1780291930-gf6d536", "", { "os": "linux", "cpu": "x64" }, "sha512-L9Y8ziLgAM8yitq8pDzpfh1uUUdcTKCabv1we0uGr5N8pxthsDwUbDm/E2M7/3WRqm+DKi92ILjaD1tR8iXF8Q=="],
+    "@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1781102632-gaaab69", "", { "os": "linux", "cpu": "x64" }, "sha512-sDqwJNo2R1FKzqrHVZyTw8Cuy8AsPLERSoYxgcS+nTuinWU6rJqPDMZiAosyYjKyQwVYxuUzJJLdmcdW6l5EJA=="],
 
-    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1780291930-gf6d536", "", { "os": "win32", "cpu": "x64" }, "sha512-PQfqI8+GDjkiBUZFmbOirdL+9YFu42XrCxsVBVMefbqqhGcqUe+3XrQ8gkgLDyP/NHSTK9KX8ItN3TPbnHXEbg=="],
+    "@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1781102632-gaaab69", "", { "os": "win32", "cpu": "x64" }, "sha512-U2+OqUNG6Z+Tko4xY9HTAoMVf2r+CJP/fj5Ge5xS96sbjhhe/mzGuZtwZ8TxebFaGtbWpl6WqJZn+fzQCBBJeQ=="],
 
     "@ampcode/sdk": ["@ampcode/sdk@0.1.0-20260605144103-g77da114", "", { "dependencies": { "@ampcode/cli": "latest", "zod": "^3.23.8" }, "bin": { "amp-sdk": "bin/amp-sdk.js" } }, "sha512-EIo9xy/qQMSNWKKmID2sOGUCVEPtnE3mMKgtw5LInedCy3U99LVK83BB45rqWGaqaCnzu99GkPruoqgIE/kyvw=="],
 
@@ -83,17 +82,5 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@ampcode/sdk/@ampcode/cli": ["@ampcode/cli@0.0.1781102632-gaaab69", "", { "optionalDependencies": { "@ampcode/cli-darwin-arm64": "0.0.1781102632-gaaab69", "@ampcode/cli-darwin-x64": "0.0.1781102632-gaaab69", "@ampcode/cli-linux-arm64": "0.0.1781102632-gaaab69", "@ampcode/cli-linux-x64": "0.0.1781102632-gaaab69", "@ampcode/cli-win32-x64": "0.0.1781102632-gaaab69" }, "bin": { "amp": "bin/amp.exe" } }, "sha512-smAPY+kwkuaindyYY+ft8xja4Nf4AzACZ4a8Y4ShBKapM9Z4aHBbqrG4N+pxJIOhwOY0qigAxwiSoHeXRmBaJw=="],
-
-    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-darwin-arm64": ["@ampcode/cli-darwin-arm64@0.0.1781102632-gaaab69", "", { "os": "darwin", "cpu": "arm64" }, "sha512-c5wos9ju//rrwTCIkVT7I0kPdnbnDr0kFHJnM0hIPLJIj/BSi5xvje9hdHOW+/korziZGu4KsfISsqUEWAaktw=="],
-
-    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-darwin-x64": ["@ampcode/cli-darwin-x64@0.0.1781102632-gaaab69", "", { "os": "darwin", "cpu": "x64" }, "sha512-dSIhBf4Z/EUZTpmyPBrl91IiQYlfkSgQpPOuwrUE5DSNPhL/6VgKHAIBUJkLsPKgC39EFFLUP5s6mGO1WtfOmg=="],
-
-    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-linux-arm64": ["@ampcode/cli-linux-arm64@0.0.1781102632-gaaab69", "", { "os": "linux", "cpu": "arm64" }, "sha512-QbsTwan90RWWr2JOdS2HbCQ835dWbFKic+uzktAgcfiWuxCvKB93SMPX27heLbjkoMnYAcLfzalv9OU9A6rcPQ=="],
-
-    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-linux-x64": ["@ampcode/cli-linux-x64@0.0.1781102632-gaaab69", "", { "os": "linux", "cpu": "x64" }, "sha512-sDqwJNo2R1FKzqrHVZyTw8Cuy8AsPLERSoYxgcS+nTuinWU6rJqPDMZiAosyYjKyQwVYxuUzJJLdmcdW6l5EJA=="],
-
-    "@ampcode/sdk/@ampcode/cli/@ampcode/cli-win32-x64": ["@ampcode/cli-win32-x64@0.0.1781102632-gaaab69", "", { "os": "win32", "cpu": "x64" }, "sha512-U2+OqUNG6Z+Tko4xY9HTAoMVf2r+CJP/fj5Ge5xS96sbjhhe/mzGuZtwZ8TxebFaGtbWpl6WqJZn+fzQCBBJeQ=="],
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.2.1",
-        "@ampcode/cli": "0.0.1780291930-gf6d536",
         "@ampcode/sdk": "0.1.0-20260605144103-g77da114"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "lint": "tsc --noEmit",
     "test": "bun test src/",
     "test:binary": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun build dist/index.js --compile --outfile dist/amp-acp-test && bun test test/",
+    "test:e2e:real": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun build dist/index.js --compile --outfile dist/amp-acp-test && bun test test/acp-real-cli-e2e.test.ts",
     "test:all": "bun run test && bun run test:binary"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.2.1",
-    "@ampcode/cli": "0.0.1780291930-gf6d536",
     "@ampcode/sdk": "0.1.0-20260605144103-g77da114"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "bun dist/index.js",
     "lint": "tsc --noEmit",
     "test": "bun test src/",
-    "test:binary": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun build dist/index.js --compile --outfile dist/amp-acp-test && bun test test/binary.test.ts",
+    "test:binary": "bun build src/index.ts --target=node --outdir=dist --entry-naming=[dir]/[name].js && bun build dist/index.js --compile --outfile dist/amp-acp-test && bun test test/",
     "test:all": "bun run test && bun run test:binary"
   },
   "dependencies": {

--- a/src/acp-protocol.test.ts
+++ b/src/acp-protocol.test.ts
@@ -64,15 +64,16 @@ describe('ACP Protocol End-to-End', () => {
     expect(response.sessionId).toMatch(/^S-/);
     expect(response.models).toBeUndefined();
     expect(response.modes).toBeUndefined();
-    expect(response.configOptions).toHaveLength(3);
-    expect(response.configOptions?.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
-    expect(response.configOptions?.map((option) => option.category)).toEqual(['mode', 'model', 'thought_level']);
-    expect(response.configOptions?.find((option) => option.id === 'effort')).toMatchObject({
-      currentValue: 'high',
+    expect(response.configOptions).toHaveLength(2);
+    expect(response.configOptions?.map((option) => option.id)).toEqual(['permission', 'amp-mode']);
+    expect(response.configOptions?.map((option) => option.category)).toEqual(['mode', 'model']);
+    expect(response.configOptions?.find((option) => option.id === 'amp-mode')).toMatchObject({
+      currentValue: 'medium',
       options: [
-        { value: 'high', name: 'high' },
-        { value: 'xhigh', name: 'xhigh' },
-        { value: 'max', name: 'max' },
+        { value: 'low', name: 'Low' },
+        { value: 'medium', name: 'Medium' },
+        { value: 'high', name: 'High' },
+        { value: 'ultra', name: 'Ultra' },
       ],
     });
   });
@@ -85,70 +86,27 @@ describe('ACP Protocol End-to-End', () => {
 
     const result = await agentConnection.setSessionConfigOption({
       sessionId: session.sessionId,
-      configId: 'effort',
-      value: 'xhigh',
+      configId: 'amp-mode',
+      value: 'high',
     });
 
-    expect(result.configOptions).toHaveLength(3);
-    expect(result.configOptions.find((option) => option.id === 'effort')).toMatchObject({
-      currentValue: 'xhigh',
+    expect(result.configOptions).toHaveLength(2);
+    expect(result.configOptions.find((option) => option.id === 'amp-mode')).toMatchObject({
+      currentValue: 'high',
     });
   });
 
-  it('should hide effort config when Amp mode is rush', async () => {
+  it('should reject legacy Amp modes', async () => {
     const session = await agentConnection.newSession({
       cwd: '/tmp',
       mcpServers: [],
     });
 
-    const rush = await agentConnection.setSessionConfigOption({
+    await expect(agentConnection.setSessionConfigOption({
       sessionId: session.sessionId,
       configId: 'amp-mode',
       value: 'rush',
-    });
-    expect(rush.configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode']);
-
-    const smart = await agentConnection.setSessionConfigOption({
-      sessionId: session.sessionId,
-      configId: 'amp-mode',
-      value: 'smart',
-    });
-    expect(smart.configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
-  });
-
-  it('should scope effort options by Amp mode', async () => {
-    const session = await agentConnection.newSession({
-      cwd: '/tmp',
-      mcpServers: [],
-    });
-
-    const deep = await agentConnection.setSessionConfigOption({
-      sessionId: session.sessionId,
-      configId: 'amp-mode',
-      value: 'deep',
-    });
-    expect(deep.configOptions.find((option) => option.id === 'effort')).toMatchObject({
-      currentValue: 'medium',
-      options: [
-        { value: 'low', name: 'low' },
-        { value: 'medium', name: 'medium' },
-        { value: 'xhigh', name: 'xhigh' },
-      ],
-    });
-
-    const smart = await agentConnection.setSessionConfigOption({
-      sessionId: session.sessionId,
-      configId: 'amp-mode',
-      value: 'smart',
-    });
-    expect(smart.configOptions.find((option) => option.id === 'effort')).toMatchObject({
-      currentValue: 'high',
-      options: [
-        { value: 'high', name: 'high' },
-        { value: 'xhigh', name: 'xhigh' },
-        { value: 'max', name: 'max' },
-      ],
-    });
+    })).rejects.toThrow('Internal error');
   });
 
   it('should handle newSession with MCP servers', async () => {

--- a/src/amp-transport.test.ts
+++ b/src/amp-transport.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  buildAmpCliArgs,
+  createAmpTransport,
+  createCliTransport,
+  type AmpExecutionOptions,
+  type AmpStreamMessage,
+} from './amp-transport.js';
+
+const baseOptions: AmpExecutionOptions = {
+  cwd: '/tmp/project',
+  env: { TERM: 'dumb' },
+  mode: 'smart',
+};
+
+let fixtureDir: string;
+let fixturePath: string;
+
+beforeAll(async () => {
+  fixtureDir = await mkdtemp(path.join(os.tmpdir(), 'amp-transport-test-'));
+  fixturePath = path.join(fixtureDir, 'fake-amp.mjs');
+  await writeFile(fixturePath, `
+let prompt = '';
+for await (const chunk of process.stdin) prompt += chunk;
+if (prompt === 'fail') {
+  console.error('fixture failure');
+  process.exit(2);
+}
+console.log(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'T-cli-test' }));
+if (prompt === 'wait') await new Promise((resolve) => setTimeout(resolve, 30000));
+console.log(JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: prompt }));
+`);
+});
+
+afterAll(async () => {
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+async function collect(stream: AsyncIterable<AmpStreamMessage>): Promise<AmpStreamMessage[]> {
+  const messages: AmpStreamMessage[] = [];
+  for await (const message of stream) messages.push(message);
+  return messages;
+}
+
+describe('Amp transport', () => {
+  it('selects both supported transports', () => {
+    expect(createAmpTransport('sdk')).toBeDefined();
+    expect(createAmpTransport('cli')).toBeDefined();
+    expect(() => createAmpTransport('other')).toThrow('Unsupported AMP_ACP_TRANSPORT: other');
+  });
+
+  it('builds arguments for a new CLI thread', () => {
+    expect(buildAmpCliArgs(baseOptions)).toEqual([
+      '--execute',
+      '--stream-json',
+      '--mode',
+      'smart',
+    ]);
+  });
+
+  it('builds arguments for continuing a specific CLI thread', () => {
+    expect(buildAmpCliArgs({
+      ...baseOptions,
+      continue: 'T-test-thread',
+      effort: 'xhigh',
+      dangerouslyAllowAll: true,
+      mcpConfig: { exa: { url: 'https://mcp.exa.ai/mcp' } },
+    })).toEqual([
+      'threads',
+      'continue',
+      'T-test-thread',
+      '--execute',
+      '--stream-json',
+      '--mode',
+      'smart',
+      '--effort',
+      'xhigh',
+      '--dangerously-allow-all',
+      '--mcp-config',
+      '{"exa":{"url":"https://mcp.exa.ai/mcp"}}',
+    ]);
+  });
+
+  it('continues the latest CLI thread when requested', () => {
+    expect(buildAmpCliArgs({ ...baseOptions, continue: true }).slice(0, 4)).toEqual([
+      'threads',
+      'continue',
+      '--last',
+      '--execute',
+    ]);
+  });
+
+  it('streams JSON messages from the CLI process', async () => {
+    const controller = new AbortController();
+    const transport = createCliTransport(process.execPath, [fixturePath]);
+
+    const messages = await collect(transport.execute({
+      prompt: 'hello from ACP',
+      options: { ...baseOptions, cwd: fixtureDir },
+      signal: controller.signal,
+    }));
+
+    expect(messages).toEqual([
+      { type: 'system', subtype: 'init', session_id: 'T-cli-test' },
+      { type: 'result', subtype: 'success', is_error: false, result: 'hello from ACP' },
+    ]);
+  });
+
+  it('includes CLI stderr when the process fails', async () => {
+    const transport = createCliTransport(process.execPath, [fixturePath]);
+
+    await expect(collect(transport.execute({
+      prompt: 'fail',
+      options: { ...baseOptions, cwd: fixtureDir },
+      signal: new AbortController().signal,
+    }))).rejects.toThrow('Amp CLI process exited with code 2: fixture failure');
+  });
+
+  it('terminates the CLI process when cancelled', async () => {
+    const controller = new AbortController();
+    const transport = createCliTransport(process.execPath, [fixturePath]);
+    const iterator = transport.execute({
+      prompt: 'wait',
+      options: { ...baseOptions, cwd: fixtureDir },
+      signal: controller.signal,
+    })[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value?.type).toBe('system');
+    controller.abort();
+    await expect(iterator.next()).rejects.toThrow('Amp CLI process was aborted');
+  });
+});

--- a/src/amp-transport.test.ts
+++ b/src/amp-transport.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   buildAmpCliArgs,
+  buildAmpSdkOptions,
   createAmpTransport,
   createCliTransport,
   type AmpExecutionOptions,
@@ -13,7 +14,7 @@ import {
 const baseOptions: AmpExecutionOptions = {
   cwd: '/tmp/project',
   env: { TERM: 'dumb' },
-  mode: 'smart',
+  mode: 'medium',
 };
 
 let fixtureDir: string;
@@ -71,15 +72,21 @@ describe('Amp transport', () => {
       '--execute',
       '--stream-json',
       '--mode',
-      'smart',
+      'medium',
     ]);
+  });
+
+  it('maps current modes to the legacy SDK mode and effort options', () => {
+    expect(buildAmpSdkOptions({ ...baseOptions, mode: 'low' })).toMatchObject({ mode: 'rush' });
+    expect(buildAmpSdkOptions({ ...baseOptions, mode: 'medium' })).toMatchObject({ mode: 'smart', effort: 'high' });
+    expect(buildAmpSdkOptions({ ...baseOptions, mode: 'high' })).toMatchObject({ mode: 'smart', effort: 'xhigh' });
+    expect(buildAmpSdkOptions({ ...baseOptions, mode: 'ultra' })).toMatchObject({ mode: 'smart', effort: 'max' });
   });
 
   it('builds arguments for continuing a specific CLI thread', () => {
     expect(buildAmpCliArgs({
       ...baseOptions,
       continue: 'T-test-thread',
-      effort: 'xhigh',
       dangerouslyAllowAll: true,
       mcpConfig: { exa: { url: 'https://mcp.exa.ai/mcp' } },
     })).toEqual([
@@ -89,9 +96,7 @@ describe('Amp transport', () => {
       '--execute',
       '--stream-json',
       '--mode',
-      'smart',
-      '--effort',
-      'xhigh',
+      'medium',
       '--dangerously-allow-all',
       '--mcp-config',
       '{"exa":{"url":"https://mcp.exa.ai/mcp"}}',

--- a/src/amp-transport.test.ts
+++ b/src/amp-transport.test.ts
@@ -71,6 +71,7 @@ describe('Amp transport', () => {
     expect(buildAmpCliArgs(baseOptions)).toEqual([
       '--execute',
       '--stream-json',
+      '--no-archive-after-execute',
       '--mode',
       'medium',
     ]);
@@ -95,6 +96,7 @@ describe('Amp transport', () => {
       'T-test-thread',
       '--execute',
       '--stream-json',
+      '--no-archive-after-execute',
       '--mode',
       'medium',
       '--dangerously-allow-all',

--- a/src/amp-transport.test.ts
+++ b/src/amp-transport.test.ts
@@ -46,9 +46,23 @@ async function collect(stream: AsyncIterable<AmpStreamMessage>): Promise<AmpStre
 }
 
 describe('Amp transport', () => {
+  it('uses the CLI transport by default', () => {
+    const originalTransport = process.env.AMP_ACP_TRANSPORT;
+    delete process.env.AMP_ACP_TRANSPORT;
+    try {
+      expect(createAmpTransport().name).toBe('cli');
+    } finally {
+      if (originalTransport === undefined) {
+        delete process.env.AMP_ACP_TRANSPORT;
+      } else {
+        process.env.AMP_ACP_TRANSPORT = originalTransport;
+      }
+    }
+  });
+
   it('selects both supported transports', () => {
-    expect(createAmpTransport('sdk')).toBeDefined();
-    expect(createAmpTransport('cli')).toBeDefined();
+    expect(createAmpTransport('sdk').name).toBe('sdk');
+    expect(createAmpTransport('cli').name).toBe('cli');
     expect(() => createAmpTransport('other')).toThrow('Unsupported AMP_ACP_TRANSPORT: other');
   });
 

--- a/src/amp-transport.ts
+++ b/src/amp-transport.ts
@@ -1,0 +1,141 @@
+import { execute, type AmpOptions } from '@ampcode/sdk';
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+export type AmpMcpServerConfig =
+  | {
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      disabled?: boolean;
+    }
+  | {
+      url: string;
+      headers?: Record<string, string>;
+      disabled?: boolean;
+      transport?: string;
+    };
+
+export type AmpMcpConfig = Record<string, AmpMcpServerConfig>;
+
+export interface AmpExecutionOptions {
+  cwd: string;
+  env?: Record<string, string>;
+  mode?: 'deep' | 'smart' | 'rush' | 'large';
+  effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  dangerouslyAllowAll?: boolean;
+  mcpConfig?: AmpMcpConfig;
+  continue?: boolean | string;
+}
+
+export interface AmpStreamMessage {
+  type: string;
+  session_id?: string;
+  subtype?: string;
+  is_error?: boolean;
+  error?: string;
+  message?: {
+    content: unknown;
+  };
+}
+
+export interface AmpExecutionRequest {
+  prompt: string;
+  options: AmpExecutionOptions;
+  signal: AbortSignal;
+}
+
+export interface AmpTransport {
+  execute(request: AmpExecutionRequest): AsyncIterable<AmpStreamMessage>;
+}
+
+const sdkTransport: AmpTransport = {
+  execute(request) {
+    return execute({
+      prompt: request.prompt,
+      options: request.options as AmpOptions,
+      signal: request.signal,
+    });
+  },
+};
+
+export function buildAmpCliArgs(options: AmpExecutionOptions): string[] {
+  const args: string[] = [];
+
+  if (typeof options.continue === 'string') {
+    args.push('threads', 'continue', options.continue);
+  } else if (options.continue) {
+    args.push('threads', 'continue', '--last');
+  }
+
+  args.push('--execute', '--stream-json');
+  if (options.mode) args.push('--mode', options.mode);
+  if (options.effort) args.push('--effort', options.effort);
+  if (options.dangerouslyAllowAll) args.push('--dangerously-allow-all');
+  if (options.mcpConfig) args.push('--mcp-config', JSON.stringify(options.mcpConfig));
+
+  return args;
+}
+
+export function createCliTransport(
+  command = process.env.AMP_CLI_PATH ?? 'amp',
+  commandArgs: string[] = [],
+): AmpTransport {
+  return {
+    async *execute({ prompt, options, signal }) {
+      signal.throwIfAborted();
+
+      const child = spawn(command, [...commandArgs, ...buildAmpCliArgs(options)], {
+        cwd: options.cwd,
+        env: { ...process.env, ...options.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const stderr: Buffer[] = [];
+      child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+      const completion = new Promise<{ code: number | null; processSignal: NodeJS.Signals | null }>((resolve, reject) => {
+        child.once('error', reject);
+        child.once('close', (code, processSignal) => resolve({ code, processSignal }));
+      });
+      const abort = () => child.kill(process.platform === 'win32' ? 'SIGKILL' : 'SIGTERM');
+      signal.addEventListener('abort', abort, { once: true });
+
+      child.stdin.on('error', () => {});
+      child.stdin.end(prompt);
+
+      try {
+        const lines = createInterface({ input: child.stdout, crlfDelay: Number.POSITIVE_INFINITY });
+        for await (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            yield JSON.parse(line) as AmpStreamMessage;
+          } catch {
+            throw new Error(`Failed to parse JSON response, raw line: ${line}`);
+          }
+        }
+
+        const { code, processSignal } = await completion;
+        if (signal.aborted) throw new Error('Amp CLI process was aborted');
+        if (code === null) throw new Error(`Amp CLI process was killed by signal ${processSignal ?? 'unknown'}`);
+        if (code !== 0) {
+          const details = Buffer.concat(stderr).toString().trim();
+          throw new Error(`Amp CLI process exited with code ${code}${details ? `: ${details}` : ''}`);
+        }
+      } finally {
+        signal.removeEventListener('abort', abort);
+        if (!child.killed && child.exitCode === null) child.kill();
+      }
+    },
+  };
+}
+
+export function createAmpTransport(name = process.env.AMP_ACP_TRANSPORT ?? 'sdk'): AmpTransport {
+  switch (name) {
+    case 'sdk':
+      return sdkTransport;
+    case 'cli':
+      return createCliTransport();
+    default:
+      throw new Error(`Unsupported AMP_ACP_TRANSPORT: ${name}`);
+  }
+}

--- a/src/amp-transport.ts
+++ b/src/amp-transport.ts
@@ -46,10 +46,12 @@ export interface AmpExecutionRequest {
 }
 
 export interface AmpTransport {
+  readonly name: 'cli' | 'sdk';
   execute(request: AmpExecutionRequest): AsyncIterable<AmpStreamMessage>;
 }
 
 const sdkTransport: AmpTransport = {
+  name: 'sdk',
   execute(request) {
     return execute({
       prompt: request.prompt,
@@ -82,6 +84,7 @@ export function createCliTransport(
   commandArgs: string[] = [],
 ): AmpTransport {
   return {
+    name: 'cli',
     async *execute({ prompt, options, signal }) {
       signal.throwIfAborted();
 
@@ -129,7 +132,7 @@ export function createCliTransport(
   };
 }
 
-export function createAmpTransport(name = process.env.AMP_ACP_TRANSPORT ?? 'sdk'): AmpTransport {
+export function createAmpTransport(name = process.env.AMP_ACP_TRANSPORT ?? 'cli'): AmpTransport {
   switch (name) {
     case 'sdk':
       return sdkTransport;

--- a/src/amp-transport.ts
+++ b/src/amp-transport.ts
@@ -99,7 +99,7 @@ export function buildAmpCliArgs(options: AmpExecutionOptions): string[] {
     args.push('threads', 'continue', '--last');
   }
 
-  args.push('--execute', '--stream-json');
+  args.push('--execute', '--stream-json', '--no-archive-after-execute');
   if (options.mode) args.push('--mode', options.mode);
   if (options.dangerouslyAllowAll) args.push('--dangerously-allow-all');
   if (options.mcpConfig) args.push('--mcp-config', JSON.stringify(options.mcpConfig));

--- a/src/amp-transport.ts
+++ b/src/amp-transport.ts
@@ -21,8 +21,7 @@ export type AmpMcpConfig = Record<string, AmpMcpServerConfig>;
 export interface AmpExecutionOptions {
   cwd: string;
   env?: Record<string, string>;
-  mode?: 'deep' | 'smart' | 'rush' | 'large';
-  effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  mode?: 'low' | 'medium' | 'high' | 'ultra';
   dangerouslyAllowAll?: boolean;
   mcpConfig?: AmpMcpConfig;
   continue?: boolean | string;
@@ -55,11 +54,41 @@ const sdkTransport: AmpTransport = {
   execute(request) {
     return execute({
       prompt: request.prompt,
-      options: request.options as AmpOptions,
+      options: buildAmpSdkOptions(request.options),
       signal: request.signal,
     });
   },
 };
+
+export function buildAmpSdkOptions(options: AmpExecutionOptions): AmpOptions {
+  const sdkOptions: AmpOptions = {
+    cwd: options.cwd,
+    env: options.env,
+    dangerouslyAllowAll: options.dangerouslyAllowAll,
+    mcpConfig: options.mcpConfig,
+    continue: options.continue,
+  };
+
+  switch (options.mode) {
+    case 'low':
+      sdkOptions.mode = 'rush';
+      break;
+    case 'medium':
+      sdkOptions.mode = 'smart';
+      sdkOptions.effort = 'high';
+      break;
+    case 'high':
+      sdkOptions.mode = 'smart';
+      sdkOptions.effort = 'xhigh';
+      break;
+    case 'ultra':
+      sdkOptions.mode = 'smart';
+      sdkOptions.effort = 'max';
+      break;
+  }
+
+  return sdkOptions;
+}
 
 export function buildAmpCliArgs(options: AmpExecutionOptions): string[] {
   const args: string[] = [];
@@ -72,7 +101,6 @@ export function buildAmpCliArgs(options: AmpExecutionOptions): string[] {
 
   args.push('--execute', '--stream-json');
   if (options.mode) args.push('--mode', options.mode);
-  if (options.effort) args.push('--effort', options.effort);
   if (options.dangerouslyAllowAll) args.push('--dangerously-allow-all');
   if (options.mcpConfig) args.push('--mcp-config', JSON.stringify(options.mcpConfig));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,9 @@ if (process.argv.includes('--setup')) {
     }
   }
 
-  preferBundledAmpCliBinary();
+  if (process.env.AMP_ACP_TRANSPORT === 'sdk') {
+    preferBundledAmpCliBinary();
+  }
 
   runAcp();
 

--- a/src/mcp-config.ts
+++ b/src/mcp-config.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@agentclientprotocol/sdk';
-import type { AmpOptions } from '@ampcode/sdk';
+import type { AmpMcpConfig } from './amp-transport.js';
 
-export type AmpMcpConfig = Exclude<AmpOptions['mcpConfig'], string | undefined>;
+export type { AmpMcpConfig } from './amp-transport.js';
 
 export function convertAcpMcpServersToAmpConfig(mcpServers: McpServer[] | undefined | null): AmpMcpConfig {
   const mcpConfig: AmpMcpConfig = {};

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -57,24 +57,12 @@ describe('AmpAcpAgent prompt() continue option', () => {
     expect(capturedCalls).toHaveLength(1);
     expect(capturedCalls[0]!.options.continue).toBeUndefined();
     expect(capturedCalls[0]!.options.mode).toBe('smart');
+    expect(capturedCalls[0]!.options.effort).toBe('high');
   });
 
-  it('passes selected Amp model as SDK mode', async () => {
+  it('maps selected Amp mode to legacy SDK options', async () => {
     const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'deep' });
-    await agent.prompt({
-      sessionId: session.sessionId,
-      prompt: [{ type: 'text', text: 'hello' }],
-    });
-
-    expect(capturedCalls).toHaveLength(1);
-    expect(capturedCalls[0]!.options.mode).toBe('deep');
-    expect(capturedCalls[0]!.options.effort).toBe('medium');
-  });
-
-  it('passes selected Amp reasoning effort to the SDK', async () => {
-    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'effort', value: 'xhigh' });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'ultra' });
     await agent.prompt({
       sessionId: session.sessionId,
       prompt: [{ type: 'text', text: 'hello' }],
@@ -82,27 +70,12 @@ describe('AmpAcpAgent prompt() continue option', () => {
 
     expect(capturedCalls).toHaveLength(1);
     expect(capturedCalls[0]!.options.mode).toBe('smart');
-    expect(capturedCalls[0]!.options.effort).toBe('xhigh');
+    expect(capturedCalls[0]!.options.effort).toBe('max');
   });
 
-  it('passes selected deep reasoning effort to the SDK', async () => {
+  it('maps low mode to legacy SDK rush mode', async () => {
     const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'deep' });
-    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'effort', value: 'low' });
-    await agent.prompt({
-      sessionId: session.sessionId,
-      prompt: [{ type: 'text', text: 'hello' }],
-    });
-
-    expect(capturedCalls).toHaveLength(1);
-    expect(capturedCalls[0]!.options.mode).toBe('deep');
-    expect(capturedCalls[0]!.options.effort).toBe('low');
-  });
-
-  it('does not pass reasoning effort for rush mode', async () => {
-    const session = await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'effort', value: 'xhigh' });
-    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'rush' });
+    await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: 'amp-mode', value: 'low' });
     await agent.prompt({
       sessionId: session.sessionId,
       prompt: [{ type: 'text', text: 'hello' }],

--- a/src/prompt-continue.test.ts
+++ b/src/prompt-continue.test.ts
@@ -13,7 +13,10 @@ mock.module('@ampcode/sdk', () => ({
   },
 }));
 
-const { AmpAcpAgent } = await import('./server.js');
+const [{ AmpAcpAgent }, { createAmpTransport }] = await Promise.all([
+  import('./server.js'),
+  import('./amp-transport.js'),
+]);
 
 const mockClient = {
   sessionUpdate: async () => {},
@@ -32,7 +35,7 @@ describe('AmpAcpAgent prompt() continue option', () => {
   beforeEach(async () => {
     capturedCalls.length = 0;
     delete process.env.AMP_ACP_CONTINUE_LATEST;
-    agent = new AmpAcpAgent(mockClient);
+    agent = new AmpAcpAgent(mockClient, createAmpTransport('sdk'));
     await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -342,7 +342,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
           s.threadId = message.session_id;
         }
 
-        if (message.type === 'assistant') {
+        if (message.type === 'assistant' || message.type === 'user') {
           for (const n of toAcpNotifications(message, params.sessionId)) {
             try {
               await this.client.sessionUpdate(n);

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,11 @@ import {
   type ClientCapabilities,
   type SessionConfigOption,
 } from '@agentclientprotocol/sdk';
-import { execute, type AmpOptions, type StreamMessage } from '@ampcode/sdk';
+import {
+  createAmpTransport,
+  type AmpExecutionOptions,
+  type AmpTransport,
+} from './amp-transport.js';
 import { convertAcpMcpServersToAmpConfig, type AmpMcpConfig } from './mcp-config.js';
 import { toAcpNotifications } from './to-acp.js';
 import path from 'node:path';
@@ -174,11 +178,13 @@ interface InitializeResponseWithAgentInfo extends InitializeResponse {
 
 export class AmpAcpAgent implements Agent {
   private client: AgentSideConnection;
+  private transport: AmpTransport;
   sessions = new Map<string, SessionState>();
   private clientCapabilities?: ClientCapabilities;
 
-  constructor(client: AgentSideConnection) {
+  constructor(client: AgentSideConnection, transport = createAmpTransport()) {
     this.client = client;
+    this.transport = transport;
   }
 
   async initialize(request: InitializeRequest): Promise<InitializeResponseWithAgentInfo> {
@@ -302,7 +308,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
       }
     }
 
-    const options: AmpOptions = {
+    const options: AmpExecutionOptions = {
       cwd: s.cwd,
       env: { TERM: 'dumb' },
       mode: s.model,
@@ -331,7 +337,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
     s.controller = controller;
 
     try {
-      for await (const message of execute({ prompt: textInput, options, signal: controller.signal })) {
+      for await (const message of this.transport.execute({ prompt: textInput, options, signal: controller.signal })) {
         if (!s.threadId && message.session_id) {
           s.threadId = message.session_id;
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,40 +35,33 @@ import packageJson from '../package.json';
 const PACKAGE_VERSION: string = packageJson.version;
 const CONFIG_PERMISSION = 'permission';
 const CONFIG_AMP_MODE = 'amp-mode';
-const CONFIG_EFFORT = 'effort';
 const PERMISSION_MODES = ['default', 'bypass'] as const;
-const AMP_SMART_EFFORT_LEVELS = ['high', 'xhigh', 'max'] as const;
-const AMP_DEEP_EFFORT_LEVELS = ['low', 'medium', 'xhigh'] as const;
 
 const AMP_MODELS = [
   {
-    modelId: 'smart',
-    name: 'Smart',
-    description: 'Amp smart mode: maximum capability and autonomy for general coding tasks.',
+    modelId: 'low',
+    name: 'Low',
+    description: 'Fast and economical for simple, well-defined tasks.',
   },
   {
-    modelId: 'deep',
-    name: 'Deep',
-    description: 'Amp deep mode: extended reasoning for complex tasks.',
+    modelId: 'medium',
+    name: 'Medium',
+    description: 'Balanced capability and cost for everyday coding tasks.',
   },
   {
-    modelId: 'rush',
-    name: 'Rush',
-    description: 'Amp rush mode: fast responses for small, well-defined tasks.',
+    modelId: 'high',
+    name: 'High',
+    description: 'Greater capability and reasoning for difficult tasks.',
+  },
+  {
+    modelId: 'ultra',
+    name: 'Ultra',
+    description: 'Maximum capability for the most demanding tasks.',
   },
 ] as const;
 
 type AmpModelId = typeof AMP_MODELS[number]['modelId'];
-type AmpEffortMode = Extract<AmpModelId, 'smart' | 'deep'>;
 type PermissionMode = typeof PERMISSION_MODES[number];
-type AmpSmartEffort = typeof AMP_SMART_EFFORT_LEVELS[number];
-type AmpDeepEffort = typeof AMP_DEEP_EFFORT_LEVELS[number];
-type AmpEffort = AmpSmartEffort | AmpDeepEffort;
-
-interface SessionEfforts {
-  smart: AmpSmartEffort;
-  deep: AmpDeepEffort;
-}
 
 function isAmpModelId(modelId: string): modelId is AmpModelId {
   return AMP_MODELS.some((model) => model.modelId === modelId);
@@ -78,29 +71,8 @@ function isPermissionMode(mode: string): mode is PermissionMode {
   return PERMISSION_MODES.some((permissionMode) => permissionMode === mode);
 }
 
-function supportsReasoningEffort(model: AmpModelId): model is AmpEffortMode {
-  return model === 'smart' || model === 'deep';
-}
-
-function effortLevelsForModel(model: AmpEffortMode): readonly AmpEffort[] {
-  return model === 'smart' ? AMP_SMART_EFFORT_LEVELS : AMP_DEEP_EFFORT_LEVELS;
-}
-
-function isSmartEffort(effort: string): effort is AmpSmartEffort {
-  return AMP_SMART_EFFORT_LEVELS.some((level) => level === effort);
-}
-
-function isDeepEffort(effort: string): effort is AmpDeepEffort {
-  return AMP_DEEP_EFFORT_LEVELS.some((level) => level === effort);
-}
-
-function currentEffort(s: Pick<SessionState, 'model' | 'efforts'>): AmpEffort | undefined {
-  if (!supportsReasoningEffort(s.model)) return undefined;
-  return s.efforts[s.model];
-}
-
-function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'efforts'>): SessionConfigOption[] {
-  const options: SessionConfigOption[] = [
+function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model'>): SessionConfigOption[] {
+  return [
     {
       type: 'select',
       id: CONFIG_PERMISSION,
@@ -126,7 +98,7 @@ function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'eff
       type: 'select',
       id: CONFIG_AMP_MODE,
       name: 'Amp Mode',
-      description: 'Select the Amp SDK execution mode.',
+      description: 'Select the Amp execution mode.',
       category: 'model',
       currentValue: s.model,
       options: AMP_MODELS.map((model) => ({
@@ -136,24 +108,6 @@ function buildSessionConfigOptions(s: Pick<SessionState, 'mode' | 'model' | 'eff
       })),
     },
   ];
-
-  if (supportsReasoningEffort(s.model)) {
-    const effortLevels = effortLevelsForModel(s.model);
-    options.push({
-      type: 'select',
-      id: CONFIG_EFFORT,
-      name: 'Effort',
-      description: `Set model reasoning effort for Amp ${s.model} mode.`,
-      category: 'thought_level',
-      currentValue: s.efforts[s.model],
-      options: effortLevels.map((effort) => ({
-        value: effort,
-        name: effort,
-      })),
-    });
-  }
-
-  return options;
 }
 
 interface SessionState {
@@ -163,7 +117,6 @@ interface SessionState {
   active: boolean;
   mode: PermissionMode;
   model: AmpModelId;
-  efforts: SessionEfforts;
   mcpConfig: AmpMcpConfig;
   cwd: string;
 }
@@ -229,8 +182,7 @@ export class AmpAcpAgent implements Agent {
       cancelled: false,
       active: false,
       mode: 'default',
-      model: 'smart',
-      efforts: { smart: 'high', deep: 'medium' },
+      model: 'medium',
       mcpConfig,
       cwd: params.cwd || process.cwd(),
     };
@@ -314,10 +266,6 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
       mode: s.model,
     };
 
-    if (supportsReasoningEffort(s.model)) {
-      options.effort = currentEffort(s);
-    }
-
     if (s.mode === 'bypass') {
       options.dangerouslyAllowAll = true;
     }
@@ -340,6 +288,7 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
       for await (const message of this.transport.execute({ prompt: textInput, options, signal: controller.signal })) {
         if (!s.threadId && message.session_id) {
           s.threadId = message.session_id;
+          console.error(`[amp] thread ${s.threadId}`);
         }
 
         if (message.type === 'assistant' || message.type === 'user') {
@@ -410,22 +359,6 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLA
           throw new Error(`Unsupported Amp mode: ${params.value}`);
         }
         s.model = params.value;
-        break;
-      case CONFIG_EFFORT:
-        if (!supportsReasoningEffort(s.model)) {
-          throw new Error(`Effort is not supported for Amp mode: ${s.model}`);
-        }
-        if (s.model === 'smart') {
-          if (!isSmartEffort(params.value)) {
-            throw new Error(`Unsupported effort for smart: ${params.value}`);
-          }
-          s.efforts.smart = params.value;
-        } else {
-          if (!isDeepEffort(params.value)) {
-            throw new Error(`Unsupported effort for deep: ${params.value}`);
-          }
-          s.efforts.deep = params.value;
-        }
         break;
       default:
         throw new Error(`Unsupported config option: ${params.configId}`);

--- a/src/to-acp.ts
+++ b/src/to-acp.ts
@@ -45,7 +45,7 @@ type AmpContentBlock = AmpContentText | AmpContentImage | AmpContentThinking | A
 interface AmpMessage {
   type: string;
   message?: {
-    content: string | AmpContentBlock[];
+    content: unknown;
   };
   session_id?: string;
 }

--- a/test/acp-client-e2e.test.ts
+++ b/test/acp-client-e2e.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  PROTOCOL_VERSION,
+  client,
+  methods,
+  ndJsonStream,
+  type SessionNotification,
+} from '@agentclientprotocol/sdk';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { Readable, Writable } from 'node:stream';
+import os from 'node:os';
+import path from 'node:path';
+
+const BINARY_PATH = path.resolve(__dirname, '../dist/amp-acp-test');
+
+let fixtureDir: string;
+let fakeAmpPath: string;
+
+beforeAll(async () => {
+  fixtureDir = await mkdtemp(path.join(os.tmpdir(), 'amp-acp-e2e-'));
+  fakeAmpPath = path.join(fixtureDir, 'amp');
+  await writeFile(fakeAmpPath, `#!/usr/bin/env node
+let prompt = '';
+for await (const chunk of process.stdin) prompt += chunk;
+
+const continued = process.argv.includes('continue');
+console.log(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'T-acp-e2e' }));
+if (prompt === 'cancel me') await new Promise((resolve) => setTimeout(resolve, 30000));
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: { content: [
+    { type: 'thinking', thinking: 'Checking the request' },
+    { type: 'tool_use', id: 'tool-1', name: 'Read', input: { path: 'README.md' } },
+  ] },
+}));
+console.log(JSON.stringify({
+  type: 'user',
+  message: { content: [
+    { type: 'tool_result', tool_use_id: 'tool-1', content: 'fixture result', is_error: false },
+  ] },
+}));
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: { content: [{ type: 'text', text: 'reply:' + prompt + ';continued:' + continued }] },
+}));
+console.log(JSON.stringify({ type: 'result', subtype: 'success', is_error: false }));
+`);
+  await chmod(fakeAmpPath, 0o755);
+});
+
+afterAll(async () => {
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+async function stopProcess(process: ChildProcess): Promise<void> {
+  if (process.exitCode !== null) return;
+  process.stdin?.end();
+  process.kill('SIGTERM');
+  await Promise.race([
+    new Promise<void>((resolve) => process.once('exit', () => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+  ]);
+}
+
+describe('ACP client to compiled amp-acp binary', () => {
+  it('streams a complete CLI-backed prompt lifecycle and cancellation', async () => {
+    const process = spawn(BINARY_PATH, [], {
+      cwd: fixtureDir,
+      env: {
+        ...globalThis.process.env,
+        AMP_ACP_TRANSPORT: 'cli',
+        AMP_CLI_PATH: fakeAmpPath,
+        AMP_API_KEY: 'test-key',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const stderr: Buffer[] = [];
+    process.stderr!.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+    const updates: SessionNotification[] = [];
+    const stream = ndJsonStream(
+      Writable.toWeb(process.stdin!) as WritableStream<Uint8Array>,
+      Readable.toWeb(process.stdout!) as ReadableStream<Uint8Array>,
+    );
+
+    try {
+      const result = await client({ name: 'amp-acp-e2e-client' })
+        .onNotification(methods.client.session.update, (context) => {
+          updates.push(context.params);
+        })
+        .connectWith(stream, async (agent) => {
+          const initialized = await agent.request(methods.agent.initialize, {
+            protocolVersion: PROTOCOL_VERSION,
+            clientCapabilities: {},
+          });
+          const session = await agent.request(methods.agent.session.new, {
+            cwd: fixtureDir,
+            mcpServers: [],
+          });
+          const first = await agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'first prompt' }],
+          });
+          const second = await agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'second prompt' }],
+          });
+
+          const cancelledPrompt = agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'cancel me' }],
+          });
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          await agent.notify(methods.agent.session.cancel, { sessionId: session.sessionId });
+
+          return {
+            initialized,
+            first,
+            second,
+            cancelled: await cancelledPrompt,
+          };
+        });
+
+      expect(result.initialized.agentInfo?.name).toBe('amp-acp');
+      expect(result.first.stopReason).toBe('end_turn');
+      expect(result.second.stopReason).toBe('end_turn');
+      expect(result.cancelled.stopReason).toBe('cancelled');
+
+      const sessionUpdates = updates.map((notification) => notification.update);
+      expect(sessionUpdates).toContainEqual(expect.objectContaining({ sessionUpdate: 'agent_thought_chunk' }));
+      expect(sessionUpdates).toContainEqual(expect.objectContaining({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tool-1',
+      }));
+      expect(sessionUpdates).toContainEqual(expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'tool-1',
+        status: 'completed',
+      }));
+      expect(sessionUpdates).toContainEqual(expect.objectContaining({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'reply:first prompt;continued:false' },
+      }));
+      expect(sessionUpdates).toContainEqual(expect.objectContaining({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'reply:second prompt;continued:true' },
+      }));
+    } catch (error) {
+      const logs = Buffer.concat(stderr).toString().trim();
+      throw new Error(`${error instanceof Error ? error.message : String(error)}${logs ? `\namp-acp stderr:\n${logs}` : ''}`);
+    } finally {
+      await stopProcess(process);
+    }
+  });
+});

--- a/test/acp-real-cli-e2e.test.ts
+++ b/test/acp-real-cli-e2e.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  PROTOCOL_VERSION,
+  client,
+  methods,
+  ndJsonStream,
+  type SessionNotification,
+} from '@agentclientprotocol/sdk';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { Readable, Writable } from 'node:stream';
+import os from 'node:os';
+import path from 'node:path';
+
+const RUN_LIVE_E2E = process.env.AMP_ACP_LIVE_E2E === '1';
+const BINARY_PATH = path.resolve(__dirname, '../dist/amp-acp-test');
+const REAL_CLI_PATH = process.env.AMP_ACP_REAL_CLI_PATH ?? 'amp';
+const CONTINUATION_TOKEN = 'Kestrel-4179-Cobalt';
+const liveDescribe = RUN_LIVE_E2E ? describe : describe.skip;
+
+let fixtureDir = '';
+
+beforeAll(async () => {
+  if (!RUN_LIVE_E2E) return;
+
+  const version = spawnSync(REAL_CLI_PATH, ['--version'], { encoding: 'utf8' });
+  if (version.status !== 0) {
+    throw new Error(`Unable to run real Amp CLI at ${REAL_CLI_PATH}: ${version.stderr.trim()}`);
+  }
+  console.error(`[real-e2e] Amp CLI ${version.stdout.trim()}`);
+  fixtureDir = await mkdtemp(path.join(os.tmpdir(), 'amp-acp-real-e2e-'));
+});
+
+afterAll(async () => {
+  if (fixtureDir) await rm(fixtureDir, { recursive: true, force: true });
+});
+
+async function stopProcess(process: ChildProcess): Promise<void> {
+  if (process.exitCode !== null) return;
+  process.stdin?.end();
+  process.kill('SIGTERM');
+  await Promise.race([
+    new Promise<void>((resolve) => process.once('exit', () => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+  ]);
+}
+
+liveDescribe('ACP client to real Amp CLI', () => {
+  it('streams two low-mode turns on the same real Amp thread', async () => {
+    const process = spawn(BINARY_PATH, [], {
+      cwd: fixtureDir,
+      env: {
+        ...globalThis.process.env,
+        AMP_ACP_TRANSPORT: 'cli',
+        AMP_CLI_PATH: REAL_CLI_PATH,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const stderr: Buffer[] = [];
+    process.stderr!.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+    const updates: SessionNotification[] = [];
+    const stream = ndJsonStream(
+      Writable.toWeb(process.stdin!) as WritableStream<Uint8Array>,
+      Readable.toWeb(process.stdout!) as ReadableStream<Uint8Array>,
+    );
+
+    try {
+      const result = await client({ name: 'amp-acp-real-e2e-client' })
+        .onNotification(methods.client.session.update, (context) => {
+          updates.push(context.params);
+        })
+        .connectWith(stream, async (agent) => {
+          await agent.request(methods.agent.initialize, {
+            protocolVersion: PROTOCOL_VERSION,
+            clientCapabilities: {},
+          });
+          const session = await agent.request(methods.agent.session.new, {
+            cwd: fixtureDir,
+            mcpServers: [],
+          });
+          const config = await agent.request(methods.agent.session.setConfigOption, {
+            sessionId: session.sessionId,
+            configId: 'amp-mode',
+            value: 'low',
+          });
+
+          const first = await agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{
+              type: 'text',
+              text: `Remember the token ${CONTINUATION_TOKEN} for my next message. Reply with exactly AMP_ACP_REAL_E2E_OK and nothing else. Do not use tools or modify files.`,
+            }],
+          });
+          const firstUpdateCount = updates.length;
+          const second = await agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{
+              type: 'text',
+              text: 'Reply with exactly the token I asked you to remember in my previous message. Do not use tools or modify files.',
+            }],
+          });
+
+          return { config, first, second, firstUpdateCount };
+        });
+
+      const assistantText = (from: number, to?: number) => updates
+        .slice(from, to)
+        .map((notification) => notification.update)
+        .filter((update) => update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text')
+        .map((update) => update.content.text)
+        .join('');
+
+      expect(result.config.configOptions.find((option) => option.id === 'amp-mode')?.currentValue).toBe('low');
+      expect(result.first.stopReason).toBe('end_turn');
+      expect(result.second.stopReason).toBe('end_turn');
+      expect(assistantText(0, result.firstUpdateCount)).toContain('AMP_ACP_REAL_E2E_OK');
+      expect(assistantText(result.firstUpdateCount)).toContain(CONTINUATION_TOKEN);
+
+      const logs = Buffer.concat(stderr).toString();
+      const threadId = logs.match(/\[amp\] thread (T-[^\s]+)/)?.[1];
+      expect(threadId).toBeDefined();
+      console.error(`[real-e2e] verified continuation on ${threadId}`);
+    } catch (error) {
+      const logs = Buffer.concat(stderr).toString().trim();
+      throw new Error(`${error instanceof Error ? error.message : String(error)}${logs ? `\namp-acp stderr:\n${logs}` : ''}`);
+    } finally {
+      await stopProcess(process);
+    }
+  }, 180_000);
+});

--- a/test/binary.test.ts
+++ b/test/binary.test.ts
@@ -133,14 +133,14 @@ describe('Binary integration tests', () => {
     expect(resp.result!.modes).toBeUndefined();
     expect(resp.result!.models).toBeUndefined();
     const configOptions = resp.result!.configOptions as Array<{ id: string; category?: string; currentValue?: string; options?: Array<{ value: string }> }>;
-    expect(configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode', 'effort']);
-    expect(configOptions.map((option) => option.category)).toEqual(['mode', 'model', 'thought_level']);
-    const effort = configOptions.find((option) => option.id === 'effort')!;
-    expect(effort.currentValue).toBe('high');
-    expect(effort.options?.map((option) => option.value)).toEqual(['high', 'xhigh', 'max']);
+    expect(configOptions.map((option) => option.id)).toEqual(['permission', 'amp-mode']);
+    expect(configOptions.map((option) => option.category)).toEqual(['mode', 'model']);
+    const mode = configOptions.find((option) => option.id === 'amp-mode')!;
+    expect(mode.currentValue).toBe('medium');
+    expect(mode.options?.map((option) => option.value)).toEqual(['low', 'medium', 'high', 'ultra']);
   });
 
-  it('session/set_config_option updates effort options for Amp mode', async () => {
+  it('session/set_config_option updates Amp mode', async () => {
     const sessionResp = await sendAndWait('session/new', {
       cwd: '/tmp/test',
       mcpServers: [],
@@ -150,14 +150,14 @@ describe('Binary integration tests', () => {
     const resp = await sendAndWait('session/set_config_option', {
       sessionId,
       configId: 'amp-mode',
-      value: 'deep',
+      value: 'low',
     });
 
     expect(resp.result).toBeDefined();
     const configOptions = resp.result!.configOptions as Array<{ id: string; currentValue?: string; options?: Array<{ value: string }> }>;
-    const effort = configOptions.find((option) => option.id === 'effort')!;
-    expect(effort.currentValue).toBe('medium');
-    expect(effort.options?.map((option) => option.value)).toEqual(['low', 'medium', 'xhigh']);
+    const mode = configOptions.find((option) => option.id === 'amp-mode')!;
+    expect(mode.currentValue).toBe('low');
+    expect(mode.options?.map((option) => option.value)).toEqual(['low', 'medium', 'high', 'ultra']);
   });
 
   it('session/new with MCP servers returns valid sessionId', async () => {


### PR DESCRIPTION
## Summary

- introduce an Amp transport boundary so the ACP agent no longer calls the SDK directly
- use the installed/bundled Amp CLI and its streaming JSON interface as the default transport
- keep `@ampcode/sdk` available as an explicit compatibility fallback with `AMP_ACP_TRANSPORT=sdk`
- support streaming JSON, thread continuation, MCP configuration, process errors, and cancellation in the CLI transport
- update installation and authentication documentation for the CLI-first runtime
- add an end-to-end test that drives the compiled amp-acp binary with the official ACP client SDK and a deterministic fake Amp CLI
- forward CLI `user` stream messages so tool results complete their corresponding ACP tool calls

This intentionally preserves the currently pinned CLI's `smart`/`deep`/`rush` and effort behavior. Migrating to Amp's new `low`/`medium`/`high`/`ultra` dial will be handled as part of the planned major/breaking release rather than mixed into the transport refactor.

This is the first implementation step for #46, which tracks upgrading the CLI, eventually retiring the SDK fallback if it no longer provides value, and investigating orb-backed ACP sessions.

## End-to-end coverage

The new test exercises this complete process boundary without requiring an Amp account or spending inference credits:

`ACP SDK client -> compiled amp-acp binary -> CLI transport -> fake Amp CLI`

It verifies initialization, session creation, streamed thinking, tool call start/completion, assistant text, thread continuation, prompt completion, and ACP cancellation.

## Testing

- `bun run lint`
- `bun run build`
- `bun run test:all` (56 source tests, 8 binary protocol tests, 1 full ACP client E2E test)